### PR TITLE
Update MBusino.ino

### DIFF
--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -125,7 +125,7 @@ bool engelmann = false;
 bool waitForRestart = false;
 
 unsigned long timerMQTT = 15000;
-unsigned long timerSensorRefresh1 = 0;
+
 unsigned long timerSensorRefresh2 = 0;
 unsigned long timerMbus = 0;
 unsigned long timerDebug = 0;
@@ -361,16 +361,11 @@ void loop() {
   }
   ///////////////////////////////////////////////////////////
   
-
-  if(userData.extension > 0){
-    if ((millis() - timerSensorRefresh1) > 200) {  // springt in die Funktion zum anstoßen der aktuallisierung der Sensorwerte
-      sensorRefresh1();
-      timerSensorRefresh1 = (millis() - 1000);
-    }
+  
     if ((millis() - timerSensorRefresh2) > 1000) {  // springt in die Funktion zum holen der neuen Sensorwerte
       sensorRefresh2();
-      timerSensorRefresh1 = millis();
       timerSensorRefresh2 = millis();
+      sensorRefresh1();   // springt in die Funktion zum anstoßen der aktuallisierung der Sensorwerte
     }
   }  
   if (millis() > (timerMQTT + userData.sensorInterval)) { //MQTT Nachrichten senden


### PR DESCRIPTION
Trigger for querying the sensor values now directly after updating the values. 
Background: Several DS18B20s had timing problems with the old solution and the entire OneWire-Part of the sketch was blocked as a result. 