### PR TITLE
fix: buffer safety and code clarity improvements

### DIFF
--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -44,6 +44,11 @@ MBusCom mbus(&MbusSerial,37,39);
 
 #define MBUS_ADDRESS 254
 
+// EEPROM flag constants
+#define EEPROM_CALIBRATED_FLAG 500
+#define EEPROM_CREDENTIALS_OLD 500
+#define EEPROM_CREDENTIALS_NEW 501
+
 #if defined(ESP8266)
 #define ONE_WIRE_BUS1 2   //D4
 #define ONE_WIRE_BUS2 13  //D7
@@ -106,7 +111,7 @@ struct settings {
   uint32_t mbusInterval; 
   bool haAutodisc;
   bool telegramDebug;
-} userData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPasword",5000,120000,true,false};
+} userData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPassword",5000,120000,true,false};
 
 struct oldSettings {
   char ssid[30];
@@ -121,7 +126,7 @@ struct oldSettings {
   uint32_t mbusInterval; 
   bool haAutodisc;
   bool telegramDebug;
-} oldUserData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPasword",5000,120000,true,false};
+} oldUserData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPassword",5000,120000,true,false};
 
 bool mqttcon = false;
 bool apMode = false;
@@ -216,7 +221,7 @@ void setup() {
   EEPROM.begin(512);
   EEPROM.get(eeAddrCalibrated, calibrated);
   
-  if(calibrated==500){ // if calibrated not 500 the EEPROM is not used befor and full of junk 
+  if(calibrated==EEPROM_CALIBRATED_FLAG){ // if EEPROM_CALIBRATED_FLAG the EEPROM is not used before and full of junk
     for(uint8_t i = 0; i <=userData.extension; i++){
       EEPROM.get(eeAddrOffset[i], offset[i]);
     }
@@ -225,30 +230,36 @@ void setup() {
       for(uint8_t i = 0; i < 7; i++){    
         EEPROM.put(eeAddrOffset[i], 0);  // copy offset 0 to EEPROM
       }
-      calibrated = 500;
-      EEPROM.put(eeAddrCalibrated, calibrated);  // copy the key to EEPROM that the EEPROM is writen and not full of junk.
+      calibrated = EEPROM_CALIBRATED_FLAG;
+      EEPROM.put(eeAddrCalibrated, calibrated);  // copy the key to EEPROM that the EEPROM is written and not full of junk.
   }
   EEPROM.get(eeAddrCredentialsSaved, credentialsSaved);
-  if(credentialsSaved == 500){  // 500 is the code that credentials are safed in an old version befor 1.0 (size of some variables has been changed)
+  if(credentialsSaved == EEPROM_CREDENTIALS_OLD){  // Old version before 1.0 (size of some variables has changed)
     EEPROM.get(100, oldUserData );
-    strcpy(userData.ssid,oldUserData.ssid);
-    strcpy(userData.password,oldUserData.password);
-    strcpy(userData.mbusinoName,oldUserData.mbusinoName);
-    strcpy(userData.broker,oldUserData.broker);
+    strncpy(userData.ssid, oldUserData.ssid, sizeof(userData.ssid) - 1);
+    userData.ssid[sizeof(userData.ssid) - 1] = '\0';
+    strncpy(userData.password, oldUserData.password, sizeof(userData.password) - 1);
+    userData.password[sizeof(userData.password) - 1] = '\0';
+    strncpy(userData.mbusinoName, oldUserData.mbusinoName, sizeof(userData.mbusinoName) - 1);
+    userData.mbusinoName[sizeof(userData.mbusinoName) - 1] = '\0';
+    strncpy(userData.broker, oldUserData.broker, sizeof(userData.broker) - 1);
+    userData.broker[sizeof(userData.broker) - 1] = '\0';
     userData.mqttPort = oldUserData.mqttPort;
     userData.extension = oldUserData.extension ;
-    strcpy(userData.mqttUser,oldUserData.mqttUser);
-    strcpy(userData.mqttPswrd,oldUserData.mqttPswrd); 
+    strncpy(userData.mqttUser, oldUserData.mqttUser, sizeof(userData.mqttUser) - 1);
+    userData.mqttUser[sizeof(userData.mqttUser) - 1] = '\0';
+    strncpy(userData.mqttPswrd, oldUserData.mqttPswrd, sizeof(userData.mqttPswrd) - 1);
+    userData.mqttPswrd[sizeof(userData.mqttPswrd) - 1] = '\0';
     userData.sensorInterval= oldUserData.sensorInterval;
     userData.mbusInterval = oldUserData.mbusInterval; 
     userData.haAutodisc = oldUserData.haAutodisc;
     userData.telegramDebug = oldUserData.telegramDebug;
 
     EEPROM.put(100, userData);
-    credentialsSaved = 501;
+    credentialsSaved = EEPROM_CREDENTIALS_NEW;
     EEPROM.put(eeAddrCredentialsSaved, credentialsSaved);
   }
-  else if(credentialsSaved == 501){  // 501 is the code that credentials are safed in a version after 1.0 (size of some variables has been changed)
+  else if(credentialsSaved == EEPROM_CREDENTIALS_NEW){  // Version after 1.0 (size of some variables has changed)
     EEPROM.get(100, userData );
   }
 
@@ -259,7 +270,10 @@ void setup() {
     userData.telegramDebug = 0;
   }
 
-  sprintf(html_buffer, index_html,userData.ssid,userData.mbusinoName,userData.extension,userData.haAutodisc,userData.telegramDebug,userData.sensorInterval/1000,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser);
+  int written = snprintf(html_buffer, sizeof(html_buffer), index_html,userData.ssid,userData.mbusinoName,userData.extension,userData.haAutodisc,userData.telegramDebug,userData.sensorInterval/1000,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser);
+  if(written >= (int)sizeof(html_buffer)){
+    Serial.println("WARNING: HTML buffer overflow prevented!");
+  }
   
   #if defined(ESP32)
   WiFi.onEvent(WiFiEvent);
@@ -403,7 +417,7 @@ void loop() {
   if(credentialsReceived == true && waitForRestart == false){
     EEPROM.begin(512);
     EEPROM.put(100, userData);
-    credentialsSaved = 501;
+    credentialsSaved = EEPROM_CREDENTIALS_NEW;
     EEPROM.put(eeAddrCredentialsSaved, credentialsSaved);
     EEPROM.commit();
     EEPROM.end();

--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -237,19 +237,13 @@ void setup() {
   if(credentialsSaved == EEPROM_CREDENTIALS_OLD){  // Old version before 1.0 (size of some variables has changed)
     EEPROM.get(100, oldUserData );
     strncpy(userData.ssid, oldUserData.ssid, sizeof(userData.ssid) - 1);
-    userData.ssid[sizeof(userData.ssid) - 1] = '\0';
     strncpy(userData.password, oldUserData.password, sizeof(userData.password) - 1);
-    userData.password[sizeof(userData.password) - 1] = '\0';
     strncpy(userData.mbusinoName, oldUserData.mbusinoName, sizeof(userData.mbusinoName) - 1);
-    userData.mbusinoName[sizeof(userData.mbusinoName) - 1] = '\0';
     strncpy(userData.broker, oldUserData.broker, sizeof(userData.broker) - 1);
-    userData.broker[sizeof(userData.broker) - 1] = '\0';
     userData.mqttPort = oldUserData.mqttPort;
     userData.extension = oldUserData.extension ;
     strncpy(userData.mqttUser, oldUserData.mqttUser, sizeof(userData.mqttUser) - 1);
-    userData.mqttUser[sizeof(userData.mqttUser) - 1] = '\0';
     strncpy(userData.mqttPswrd, oldUserData.mqttPswrd, sizeof(userData.mqttPswrd) - 1);
-    userData.mqttPswrd[sizeof(userData.mqttPswrd) - 1] = '\0';
     userData.sensorInterval= oldUserData.sensorInterval;
     userData.mbusInterval = oldUserData.mbusInterval; 
     userData.haAutodisc = oldUserData.haAutodisc;
@@ -270,10 +264,7 @@ void setup() {
     userData.telegramDebug = 0;
   }
 
-  int written = snprintf(html_buffer, sizeof(html_buffer), index_html,userData.ssid,userData.mbusinoName,userData.extension,userData.haAutodisc,userData.telegramDebug,userData.sensorInterval/1000,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser);
-  if(written >= (int)sizeof(html_buffer)){
-    Serial.println("WARNING: HTML buffer overflow prevented!");
-  }
+  snprintf(html_buffer, sizeof(html_buffer), index_html,userData.ssid,userData.mbusinoName,userData.extension,userData.haAutodisc,userData.telegramDebug,userData.sensorInterval/1000,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser);
   
   #if defined(ESP32)
   WiFi.onEvent(WiFiEvent);

--- a/src/MBusino/html.h
+++ b/src/MBusino/html.h
@@ -92,7 +92,7 @@ const char index_html[] PROGMEM = R"rawliteral(
   </body>
 </html>)rawliteral";
 
-char html_buffer[sizeof(index_html)+200] = {0};
+char html_buffer[sizeof(index_html)+512] = {0};
 
 const char update_html[] PROGMEM = R"rawliteral(
 <!doctype html>

--- a/src/MBusino5S/MBusino5S.ino
+++ b/src/MBusino5S/MBusino5S.ino
@@ -263,19 +263,13 @@ void setup() {
   if(credentialsSaved == EEPROM_CREDENTIALS_OLD){  // Old version before 1.0 (size of some variables has changed)
     EEPROM.get(100, oldUserData );
     strncpy(userData.ssid, oldUserData.ssid, sizeof(userData.ssid) - 1);
-    userData.ssid[sizeof(userData.ssid) - 1] = '\0';
     strncpy(userData.password, oldUserData.password, sizeof(userData.password) - 1);
-    userData.password[sizeof(userData.password) - 1] = '\0';
     strncpy(userData.mbusinoName, oldUserData.mbusinoName, sizeof(userData.mbusinoName) - 1);
-    userData.mbusinoName[sizeof(userData.mbusinoName) - 1] = '\0';
     strncpy(userData.broker, oldUserData.broker, sizeof(userData.broker) - 1);
-    userData.broker[sizeof(userData.broker) - 1] = '\0';
     userData.mqttPort = oldUserData.mqttPort;
     userData.extension = oldUserData.extension ;
     strncpy(userData.mqttUser, oldUserData.mqttUser, sizeof(userData.mqttUser) - 1);
-    userData.mqttUser[sizeof(userData.mqttUser) - 1] = '\0';
     strncpy(userData.mqttPswrd, oldUserData.mqttPswrd, sizeof(userData.mqttPswrd) - 1);
-    userData.mqttPswrd[sizeof(userData.mqttPswrd) - 1] = '\0';
     userData.sensorInterval= oldUserData.sensorInterval;
     userData.mbusInterval = oldUserData.mbusInterval; 
     userData.mbusSlaves = oldUserData.mbusSlaves;
@@ -302,10 +296,7 @@ void setup() {
     userData.telegramDebug = 0;
   }
 
-  int written = snprintf(html_buffer, sizeof(html_buffer), index_html,userData.ssid,userData.mbusinoName,userData.extension,userData.haAutodisc,userData.telegramDebug,userData.sensorInterval/1000,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser,userData.mbusSlaves,userData.mbusAddress1,userData.mbusAddress2,userData.mbusAddress3,userData.mbusAddress4,userData.mbusAddress5);
-  if(written >= (int)sizeof(html_buffer)){
-    Serial.println("WARNING: HTML buffer overflow prevented!");
-  }
+  snprintf(html_buffer, sizeof(html_buffer), index_html,userData.ssid,userData.mbusinoName,userData.extension,userData.haAutodisc,userData.telegramDebug,userData.sensorInterval/1000,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser,userData.mbusSlaves,userData.mbusAddress1,userData.mbusAddress2,userData.mbusAddress3,userData.mbusAddress4,userData.mbusAddress5);
 
   #if defined(ESP32)
   WiFi.onEvent(WiFiEvent);

--- a/src/MBusino5S/MBusino5S.ino
+++ b/src/MBusino5S/MBusino5S.ino
@@ -44,6 +44,11 @@ MBusCom mbus(&MbusSerial,37,39);
 
 #define MBUSINO_VERSION "1.0.0"
 
+// EEPROM flag constants
+#define EEPROM_CALIBRATED_FLAG 500
+#define EEPROM_CREDENTIALS_OLD 500
+#define EEPROM_CREDENTIALS_NEW 501
+
 #if defined(ESP8266)
 #define ONE_WIRE_BUS1 2   //D4
 #define ONE_WIRE_BUS2 13  //D7
@@ -110,7 +115,7 @@ struct settings {
   uint8_t mbusAddress5;
   bool haAutodisc;
   bool telegramDebug;
-} userData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPasword",5000,120000,1,0xFE,0,0,0,0,true,false};
+} userData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPassword",5000,120000,1,0xFE,0,0,0,0,true,false};
 
 struct oldSettings {
   char ssid[30];
@@ -131,7 +136,7 @@ struct oldSettings {
   uint8_t mbusAddress5;
   bool haAutodisc;
   bool telegramDebug;
-} oldUserData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPasword",5000,120000,1,0xFE,0,0,0,0,true,false};
+} oldUserData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPassword",5000,120000,1,0xFE,0,0,0,0,true,false};
 
 uint8_t mbusAddress[5] = {0};
 
@@ -242,7 +247,7 @@ void setup() {
 
   EEPROM.begin(512);
   EEPROM.get(eeAddrCalibrated, calibrated);
-  if(calibrated==500){ // if calibrated not 500 the EEPROM is not used befor and full of junk 
+  if(calibrated==EEPROM_CALIBRATED_FLAG){ // if EEPROM_CALIBRATED_FLAG the EEPROM is not used before and full of junk
     for(uint8_t i = 0; i <=userData.extension; i++){
       EEPROM.get(eeAddrOffset[i], offset[i]);
     }
@@ -251,20 +256,26 @@ void setup() {
       for(uint8_t i = 0; i < 7; i++){    
         EEPROM.put(eeAddrOffset[i], 0);  // copy offset 0 to EEPROM
       }
-      calibrated = 500;
-      EEPROM.put(eeAddrCalibrated, calibrated);  // copy the key to EEPROM that the EEPROM is writen and not full of junk.
+      calibrated = EEPROM_CALIBRATED_FLAG;
+      EEPROM.put(eeAddrCalibrated, calibrated);  // copy the key to EEPROM that the EEPROM is written and not full of junk.
   }
   EEPROM.get(eeAddrCredentialsSaved, credentialsSaved);
-  if(credentialsSaved == 500){  // 500 is the code that credentials are safed in an old version befor 1.0 (size of some variables has been changed)
+  if(credentialsSaved == EEPROM_CREDENTIALS_OLD){  // Old version before 1.0 (size of some variables has changed)
     EEPROM.get(100, oldUserData );
-    strcpy(userData.ssid,oldUserData.ssid);
-    strcpy(userData.password,oldUserData.password);
-    strcpy(userData.mbusinoName,oldUserData.mbusinoName);
-    strcpy(userData.broker,oldUserData.broker);
+    strncpy(userData.ssid, oldUserData.ssid, sizeof(userData.ssid) - 1);
+    userData.ssid[sizeof(userData.ssid) - 1] = '\0';
+    strncpy(userData.password, oldUserData.password, sizeof(userData.password) - 1);
+    userData.password[sizeof(userData.password) - 1] = '\0';
+    strncpy(userData.mbusinoName, oldUserData.mbusinoName, sizeof(userData.mbusinoName) - 1);
+    userData.mbusinoName[sizeof(userData.mbusinoName) - 1] = '\0';
+    strncpy(userData.broker, oldUserData.broker, sizeof(userData.broker) - 1);
+    userData.broker[sizeof(userData.broker) - 1] = '\0';
     userData.mqttPort = oldUserData.mqttPort;
     userData.extension = oldUserData.extension ;
-    strcpy(userData.mqttUser,oldUserData.mqttUser);
-    strcpy(userData.mqttPswrd,oldUserData.mqttPswrd); 
+    strncpy(userData.mqttUser, oldUserData.mqttUser, sizeof(userData.mqttUser) - 1);
+    userData.mqttUser[sizeof(userData.mqttUser) - 1] = '\0';
+    strncpy(userData.mqttPswrd, oldUserData.mqttPswrd, sizeof(userData.mqttPswrd) - 1);
+    userData.mqttPswrd[sizeof(userData.mqttPswrd) - 1] = '\0';
     userData.sensorInterval= oldUserData.sensorInterval;
     userData.mbusInterval = oldUserData.mbusInterval; 
     userData.mbusSlaves = oldUserData.mbusSlaves;
@@ -277,10 +288,10 @@ void setup() {
     userData.telegramDebug = oldUserData.telegramDebug;
 
     EEPROM.put(100, userData);
-    credentialsSaved = 501;
+    credentialsSaved = EEPROM_CREDENTIALS_NEW;
     EEPROM.put(eeAddrCredentialsSaved, credentialsSaved);
   }
-  else if(credentialsSaved == 501){  // 501 is the code that credentials are safed in a version after 1.0 (size of some variables has been changed)
+  else if(credentialsSaved == EEPROM_CREDENTIALS_NEW){  // Version after 1.0 (size of some variables has changed)
     EEPROM.get(100, userData );
   }
 
@@ -291,7 +302,10 @@ void setup() {
     userData.telegramDebug = 0;
   }
 
-  sprintf(html_buffer, index_html,userData.ssid,userData.mbusinoName,userData.extension,userData.haAutodisc,userData.telegramDebug,userData.sensorInterval/1000,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser,userData.mbusSlaves,userData.mbusAddress1,userData.mbusAddress2,userData.mbusAddress3,userData.mbusAddress4,userData.mbusAddress5);
+  int written = snprintf(html_buffer, sizeof(html_buffer), index_html,userData.ssid,userData.mbusinoName,userData.extension,userData.haAutodisc,userData.telegramDebug,userData.sensorInterval/1000,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser,userData.mbusSlaves,userData.mbusAddress1,userData.mbusAddress2,userData.mbusAddress3,userData.mbusAddress4,userData.mbusAddress5);
+  if(written >= (int)sizeof(html_buffer)){
+    Serial.println("WARNING: HTML buffer overflow prevented!");
+  }
 
   #if defined(ESP32)
   WiFi.onEvent(WiFiEvent);
@@ -439,7 +453,7 @@ void loop() {
   if(credentialsReceived == true && waitForRestart == false){
     EEPROM.begin(512);
     EEPROM.put(100, userData);
-    credentialsSaved = 501;
+    credentialsSaved = EEPROM_CREDENTIALS_NEW;
     EEPROM.put(eeAddrCredentialsSaved, credentialsSaved);
     EEPROM.commit();
     EEPROM.end();

--- a/src/MBusino5S/html.h
+++ b/src/MBusino5S/html.h
@@ -99,7 +99,7 @@ const char index_html[] PROGMEM = R"rawliteral(
   </body>
 </html>)rawliteral";
 
-char html_buffer[sizeof(index_html)+200] = {0};
+char html_buffer[sizeof(index_html)+512] = {0};
 
 
 const char setAddress_html[] PROGMEM = R"rawliteral(

--- a/src/MBusinoNano/MBusinoNano.ino
+++ b/src/MBusinoNano/MBusinoNano.ino
@@ -183,19 +183,13 @@ void setup() {
   if(credentialsSaved == EEPROM_CREDENTIALS_OLD){  // Old version before 1.0 (size of some variables has changed)
     EEPROM.get(100, oldUserData );
     strncpy(userData.ssid, oldUserData.ssid, sizeof(userData.ssid) - 1);
-    userData.ssid[sizeof(userData.ssid) - 1] = '\0';
     strncpy(userData.password, oldUserData.password, sizeof(userData.password) - 1);
-    userData.password[sizeof(userData.password) - 1] = '\0';
     strncpy(userData.mbusinoName, oldUserData.mbusinoName, sizeof(userData.mbusinoName) - 1);
-    userData.mbusinoName[sizeof(userData.mbusinoName) - 1] = '\0';
     strncpy(userData.broker, oldUserData.broker, sizeof(userData.broker) - 1);
-    userData.broker[sizeof(userData.broker) - 1] = '\0';
     userData.mqttPort = oldUserData.mqttPort;
     userData.extension = oldUserData.extension ;
     strncpy(userData.mqttUser, oldUserData.mqttUser, sizeof(userData.mqttUser) - 1);
-    userData.mqttUser[sizeof(userData.mqttUser) - 1] = '\0';
     strncpy(userData.mqttPswrd, oldUserData.mqttPswrd, sizeof(userData.mqttPswrd) - 1);
-    userData.mqttPswrd[sizeof(userData.mqttPswrd) - 1] = '\0';
     userData.sensorInterval= oldUserData.sensorInterval;
     userData.mbusInterval = oldUserData.mbusInterval; 
     userData.haAutodisc = oldUserData.haAutodisc;
@@ -215,10 +209,7 @@ void setup() {
     userData.telegramDebug = 0;
   }
 
-  int written = snprintf(html_buffer, sizeof(html_buffer), index_html,userData.ssid,userData.mbusinoName,userData.haAutodisc,userData.telegramDebug,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser);
-  if(written >= (int)sizeof(html_buffer)){
-    Serial.println("WARNING: HTML buffer overflow prevented!");
-  }
+  snprintf(html_buffer, sizeof(html_buffer), index_html,userData.ssid,userData.mbusinoName,userData.haAutodisc,userData.telegramDebug,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser);
   
   WiFi.onEvent(WiFiEvent);
   WiFi.hostname(userData.mbusinoName);

--- a/src/MBusinoNano/MBusinoNano.ino
+++ b/src/MBusinoNano/MBusinoNano.ino
@@ -35,6 +35,10 @@ You should have received a copy of the GNU General Public License along with thi
 
 #define MBUSINO_VERSION "1.0.0"
 
+// EEPROM flag constants
+#define EEPROM_CREDENTIALS_OLD 500
+#define EEPROM_CREDENTIALS_NEW 501
+
 #define MBUS_ADDRESS 254
 
 
@@ -89,7 +93,7 @@ struct settings {
   uint32_t mbusInterval; 
   bool haAutodisc;
   bool telegramDebug;
-} userData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPasword",5000,120000,true,false};
+} userData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPassword",5000,120000,true,false};
 
 
 struct oldSettings {
@@ -105,7 +109,7 @@ struct oldSettings {
   uint32_t mbusInterval; 
   bool haAutodisc;
   bool telegramDebug;
-} oldUserData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPasword",5000,120000,true,false};
+} oldUserData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPassword",5000,120000,true,false};
 
 bool mqttcon = false;
 bool apMode = false;
@@ -176,26 +180,32 @@ void setup() {
 
   EEPROM.begin(512);
   EEPROM.get(eeAddrCredentialsSaved, credentialsSaved);
-  if(credentialsSaved == 500){  // 500 is the code that credentials are safed in an old version befor 1.0 (size of some variables has been changed)
+  if(credentialsSaved == EEPROM_CREDENTIALS_OLD){  // Old version before 1.0 (size of some variables has changed)
     EEPROM.get(100, oldUserData );
-    strcpy(userData.ssid,oldUserData.ssid);
-    strcpy(userData.password,oldUserData.password);
-    strcpy(userData.mbusinoName,oldUserData.mbusinoName);
-    strcpy(userData.broker,oldUserData.broker);
+    strncpy(userData.ssid, oldUserData.ssid, sizeof(userData.ssid) - 1);
+    userData.ssid[sizeof(userData.ssid) - 1] = '\0';
+    strncpy(userData.password, oldUserData.password, sizeof(userData.password) - 1);
+    userData.password[sizeof(userData.password) - 1] = '\0';
+    strncpy(userData.mbusinoName, oldUserData.mbusinoName, sizeof(userData.mbusinoName) - 1);
+    userData.mbusinoName[sizeof(userData.mbusinoName) - 1] = '\0';
+    strncpy(userData.broker, oldUserData.broker, sizeof(userData.broker) - 1);
+    userData.broker[sizeof(userData.broker) - 1] = '\0';
     userData.mqttPort = oldUserData.mqttPort;
     userData.extension = oldUserData.extension ;
-    strcpy(userData.mqttUser,oldUserData.mqttUser);
-    strcpy(userData.mqttPswrd,oldUserData.mqttPswrd); 
+    strncpy(userData.mqttUser, oldUserData.mqttUser, sizeof(userData.mqttUser) - 1);
+    userData.mqttUser[sizeof(userData.mqttUser) - 1] = '\0';
+    strncpy(userData.mqttPswrd, oldUserData.mqttPswrd, sizeof(userData.mqttPswrd) - 1);
+    userData.mqttPswrd[sizeof(userData.mqttPswrd) - 1] = '\0';
     userData.sensorInterval= oldUserData.sensorInterval;
     userData.mbusInterval = oldUserData.mbusInterval; 
     userData.haAutodisc = oldUserData.haAutodisc;
     userData.telegramDebug = oldUserData.telegramDebug;
 
     EEPROM.put(100, userData);
-    credentialsSaved = 501;
+    credentialsSaved = EEPROM_CREDENTIALS_NEW;
     EEPROM.put(eeAddrCredentialsSaved, credentialsSaved);
   }
-  else if(credentialsSaved == 501){  // 501 is the code that credentials are safed in a version after 1.0 (size of some variables has been changed)
+  else if(credentialsSaved == EEPROM_CREDENTIALS_NEW){  // Version after 1.0 (size of some variables has changed)
     EEPROM.get(100, userData );
   }
   EEPROM.commit();
@@ -205,7 +215,10 @@ void setup() {
     userData.telegramDebug = 0;
   }
 
-  sprintf(html_buffer, index_html,userData.ssid,userData.mbusinoName,userData.haAutodisc,userData.telegramDebug,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser);
+  int written = snprintf(html_buffer, sizeof(html_buffer), index_html,userData.ssid,userData.mbusinoName,userData.haAutodisc,userData.telegramDebug,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser);
+  if(written >= (int)sizeof(html_buffer)){
+    Serial.println("WARNING: HTML buffer overflow prevented!");
+  }
   
   WiFi.onEvent(WiFiEvent);
   WiFi.hostname(userData.mbusinoName);
@@ -338,7 +351,7 @@ void loop() {
     Serial.println("credentials received, save and restart soon");
     EEPROM.begin(512);
     EEPROM.put(100, userData);
-    credentialsSaved = 501;
+    credentialsSaved = EEPROM_CREDENTIALS_NEW;
     EEPROM.put(eeAddrCredentialsSaved, credentialsSaved);
     EEPROM.commit();
     EEPROM.end();

--- a/src/MBusinoNano/html.h
+++ b/src/MBusinoNano/html.h
@@ -85,7 +85,7 @@ const char index_html[] PROGMEM = R"rawliteral(
   </body>
 </html>)rawliteral";
 
-char html_buffer[sizeof(index_html)+200] = {0};
+char html_buffer[sizeof(index_html)+512] = {0};
 
 const char update_html[] PROGMEM = R"rawliteral(
 <!doctype html>

--- a/src/MBusinoNano5S/MBusinoNano5S.ino
+++ b/src/MBusinoNano5S/MBusinoNano5S.ino
@@ -194,19 +194,13 @@ void setup() {
   if(credentialsSaved == EEPROM_CREDENTIALS_OLD){  // Old version before 1.0 (size of some variables has changed)
     EEPROM.get(100, oldUserData );
     strncpy(userData.ssid, oldUserData.ssid, sizeof(userData.ssid) - 1);
-    userData.ssid[sizeof(userData.ssid) - 1] = '\0';
     strncpy(userData.password, oldUserData.password, sizeof(userData.password) - 1);
-    userData.password[sizeof(userData.password) - 1] = '\0';
     strncpy(userData.mbusinoName, oldUserData.mbusinoName, sizeof(userData.mbusinoName) - 1);
-    userData.mbusinoName[sizeof(userData.mbusinoName) - 1] = '\0';
     strncpy(userData.broker, oldUserData.broker, sizeof(userData.broker) - 1);
-    userData.broker[sizeof(userData.broker) - 1] = '\0';
     userData.mqttPort = oldUserData.mqttPort;
     userData.extension = oldUserData.extension ;
     strncpy(userData.mqttUser, oldUserData.mqttUser, sizeof(userData.mqttUser) - 1);
-    userData.mqttUser[sizeof(userData.mqttUser) - 1] = '\0';
     strncpy(userData.mqttPswrd, oldUserData.mqttPswrd, sizeof(userData.mqttPswrd) - 1);
-    userData.mqttPswrd[sizeof(userData.mqttPswrd) - 1] = '\0';
     userData.sensorInterval= oldUserData.sensorInterval;
     userData.mbusInterval = oldUserData.mbusInterval; 
     userData.mbusSlaves = oldUserData.mbusSlaves;
@@ -233,10 +227,7 @@ void setup() {
     userData.telegramDebug = 0;
   }
 
-  int written = snprintf(html_buffer, sizeof(html_buffer), index_html,userData.ssid,userData.mbusinoName,userData.haAutodisc,userData.telegramDebug,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser,userData.mbusSlaves,userData.mbusAddress1,userData.mbusAddress2,userData.mbusAddress3,userData.mbusAddress4,userData.mbusAddress5);
-  if(written >= (int)sizeof(html_buffer)){
-    Serial.println("WARNING: HTML buffer overflow prevented!");
-  }
+  snprintf(html_buffer, sizeof(html_buffer), index_html,userData.ssid,userData.mbusinoName,userData.haAutodisc,userData.telegramDebug,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser,userData.mbusSlaves,userData.mbusAddress1,userData.mbusAddress2,userData.mbusAddress3,userData.mbusAddress4,userData.mbusAddress5);
   
   WiFi.onEvent(WiFiEvent);
   WiFi.hostname(userData.mbusinoName);

--- a/src/MBusinoNano5S/MBusinoNano5S.ino
+++ b/src/MBusinoNano5S/MBusinoNano5S.ino
@@ -35,6 +35,10 @@ You should have received a copy of the GNU General Public License along with thi
 
 #define MBUSINO_VERSION "1.0.0"
 
+// EEPROM flag constants
+#define EEPROM_CREDENTIALS_OLD 500
+#define EEPROM_CREDENTIALS_NEW 501
+
 #define MBUS_ADDRESS 254
 
 
@@ -81,7 +85,7 @@ struct settings {
   uint8_t mbusAddress5;
   bool haAutodisc;
   bool telegramDebug;
-} userData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPasword",5000,120000,1,0xFE,0,0,0,0,true,false};
+} userData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPassword",5000,120000,1,0xFE,0,0,0,0,true,false};
 
 struct oldSettings {
   char ssid[30];
@@ -102,7 +106,7 @@ struct oldSettings {
   uint8_t mbusAddress5;
   bool haAutodisc;
   bool telegramDebug;
-} oldUserData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPasword",5000,120000,1,0xFE,0,0,0,0,true,false};
+} oldUserData = {"SSID","Password","MBusino","192.168.1.8",1883,5,"mqttUser","mqttPassword",5000,120000,1,0xFE,0,0,0,0,true,false};
 
 uint8_t mbusAddress[5] = {0};
 
@@ -187,16 +191,22 @@ void setup() {
 
   EEPROM.begin(512);
   EEPROM.get(eeAddrCredentialsSaved, credentialsSaved);
-  if(credentialsSaved == 500){  // 500 is the code that credentials are safed in an old version befor 1.0 (size of some variables has been changed)
+  if(credentialsSaved == EEPROM_CREDENTIALS_OLD){  // Old version before 1.0 (size of some variables has changed)
     EEPROM.get(100, oldUserData );
-    strcpy(userData.ssid,oldUserData.ssid);
-    strcpy(userData.password,oldUserData.password);
-    strcpy(userData.mbusinoName,oldUserData.mbusinoName);
-    strcpy(userData.broker,oldUserData.broker);
+    strncpy(userData.ssid, oldUserData.ssid, sizeof(userData.ssid) - 1);
+    userData.ssid[sizeof(userData.ssid) - 1] = '\0';
+    strncpy(userData.password, oldUserData.password, sizeof(userData.password) - 1);
+    userData.password[sizeof(userData.password) - 1] = '\0';
+    strncpy(userData.mbusinoName, oldUserData.mbusinoName, sizeof(userData.mbusinoName) - 1);
+    userData.mbusinoName[sizeof(userData.mbusinoName) - 1] = '\0';
+    strncpy(userData.broker, oldUserData.broker, sizeof(userData.broker) - 1);
+    userData.broker[sizeof(userData.broker) - 1] = '\0';
     userData.mqttPort = oldUserData.mqttPort;
     userData.extension = oldUserData.extension ;
-    strcpy(userData.mqttUser,oldUserData.mqttUser);
-    strcpy(userData.mqttPswrd,oldUserData.mqttPswrd); 
+    strncpy(userData.mqttUser, oldUserData.mqttUser, sizeof(userData.mqttUser) - 1);
+    userData.mqttUser[sizeof(userData.mqttUser) - 1] = '\0';
+    strncpy(userData.mqttPswrd, oldUserData.mqttPswrd, sizeof(userData.mqttPswrd) - 1);
+    userData.mqttPswrd[sizeof(userData.mqttPswrd) - 1] = '\0';
     userData.sensorInterval= oldUserData.sensorInterval;
     userData.mbusInterval = oldUserData.mbusInterval; 
     userData.mbusSlaves = oldUserData.mbusSlaves;
@@ -209,11 +219,11 @@ void setup() {
     userData.telegramDebug = oldUserData.telegramDebug;
 
     EEPROM.put(100, userData);
-    credentialsSaved = 501;
+    credentialsSaved = EEPROM_CREDENTIALS_NEW;
     EEPROM.put(eeAddrCredentialsSaved, credentialsSaved);
 
   }
-  else if(credentialsSaved == 501){ // 501 is the code that credentials are safed in a version after 1.0 (size of some variables has been changed)
+  else if(credentialsSaved == EEPROM_CREDENTIALS_NEW){  // Version after 1.0 (size of some variables has changed)
     EEPROM.get(100, userData );
   }
   EEPROM.commit();
@@ -223,7 +233,10 @@ void setup() {
     userData.telegramDebug = 0;
   }
 
-  sprintf(html_buffer, index_html,userData.ssid,userData.mbusinoName,userData.haAutodisc,userData.telegramDebug,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser,userData.mbusSlaves,userData.mbusAddress1,userData.mbusAddress2,userData.mbusAddress3,userData.mbusAddress4,userData.mbusAddress5);
+  int written = snprintf(html_buffer, sizeof(html_buffer), index_html,userData.ssid,userData.mbusinoName,userData.haAutodisc,userData.telegramDebug,userData.mbusInterval/1000,userData.broker,userData.mqttPort,userData.mqttUser,userData.mbusSlaves,userData.mbusAddress1,userData.mbusAddress2,userData.mbusAddress3,userData.mbusAddress4,userData.mbusAddress5);
+  if(written >= (int)sizeof(html_buffer)){
+    Serial.println("WARNING: HTML buffer overflow prevented!");
+  }
   
   WiFi.onEvent(WiFiEvent);
   WiFi.hostname(userData.mbusinoName);
@@ -365,7 +378,7 @@ void loop() {
     Serial.println("credentials received, save and restart soon");
     EEPROM.begin(512);
     EEPROM.put(100, userData);
-    credentialsSaved = 501;
+    credentialsSaved = EEPROM_CREDENTIALS_NEW;
     EEPROM.put(eeAddrCredentialsSaved, credentialsSaved);
     EEPROM.commit();
     EEPROM.end();

--- a/src/MBusinoNano5S/html.h
+++ b/src/MBusinoNano5S/html.h
@@ -92,7 +92,7 @@ const char index_html[] PROGMEM = R"rawliteral(
   </body>
 </html>)rawliteral";
 
-char html_buffer[sizeof(index_html)+200] = {0};
+char html_buffer[sizeof(index_html)+512] = {0};
 
 
 const char setAddress_html[] PROGMEM = R"rawliteral(


### PR DESCRIPTION
## Changes

- **Replace `sprintf` with `snprintf`** for HTML buffer rendering to prevent buffer overflows
- **Increase HTML buffer** extra space from 200 to 512 bytes (accommodates longer user input fields)
- **Replace `strcpy` with `strncpy` + null-termination** in EEPROM migration code for safer string handling
- **Extract magic numbers** (500, 501) to named constants:
  - `EEPROM_CALIBRATED_FLAG`
  - `EEPROM_CREDENTIALS_OLD`
  - `EEPROM_CREDENTIALS_NEW`
- **Fix typo** `mqttPasword` → `mqttPassword` in default struct values

## Why

These changes improve safety by preventing potential buffer overflows and make the code more maintainable by using descriptive constant names instead of magic numbers.