### PR TITLE
feat: M-Bus Header Autodiscovery für Home Assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.3] - 2026-04-28
+
+### Added
+
+- M-Bus Header autodiscovery for Home Assistant (all 4 variants)
+- Header fields published via MQTT with type-aware loops
+- Depends on MBusinoLib 0.9.20 (a_field → address)
+
 ## [1.0.2] - 2026-04-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MBusino
-[![version](https://img.shields.io/badge/version-1.0.2-brightgreen.svg)](CHANGELOG.md)<br/>
+[![version](https://img.shields.io/badge/version-1.0.3-brightgreen.svg)](CHANGELOG.md)<br/>
 ### M-Bus --> MQTT-Gateway with shields for ESPs
 
 A **Plug and Play** solution.

--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -636,27 +636,27 @@ void loop() {
             // Publish M-Bus header via MQTT
             if (!headerObj.isNull()) {
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/address").c_str(),
-                             String("{\"value\":" + String(headerObj["a_field"].as<int>()) + "}").c_str());
+                             String(headerObj["a_field"].as<int>()).c_str());
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/id").c_str(),
-                             String("{\"value\":\"" + String(headerObj["id"].as<const char*>()) + "\"}").c_str());
+                             headerObj["id"].as<const char*>());
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/manufacturer").c_str(),
-                             String("{\"value\":\"" + String(headerObj["manufacturer"].as<const char*>()) + "\"}").c_str());
+                             headerObj["manufacturer"].as<const char*>());
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/medium").c_str(),
-                             String("{\"value\":\"" + String(headerObj["medium"].as<const char*>()) + "\"}").c_str());
+                             headerObj["medium"].as<const char*>());
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/version").c_str(),
-                             String("{\"value\":" + String(headerObj["version"].as<int>()) + "}").c_str());
+                             String(headerObj["version"].as<int>()).c_str());
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/status").c_str(),
-                             String("{\"value\":\"" + String(headerObj["status"].as<int>(), HEX) + "\"}").c_str());
+                             String(headerObj["status"].as<int>(), HEX).c_str());
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/access_counter").c_str(),
-                             String("{\"value\":" + String(headerObj["access_counter"].as<int>()) + "}").c_str());
+                             String(headerObj["access_counter"].as<int>()).c_str());
               // Status details
               JsonObject statusDetails = headerObj["status_details"];
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/battery_low").c_str(),
-                             statusDetails["battery_low"].as<bool>() ? "{\"value\":100}" : "{\"value\":0}");
+                             statusDetails["battery_low"].as<bool>() ? "true" : "false");
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/temporary_error").c_str(),
-                             statusDetails["temporary_error"].as<bool>() ? "{\"value\":\"on\"}" : "{\"value\":\"off\"}");
+                             statusDetails["temporary_error"].as<bool>() ? "true" : "false");
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/permanent_error").c_str(),
-                             statusDetails["permanent_error"].as<bool>() ? "{\"value\":\"on\"}" : "{\"value\":\"off\"}");
+                             statusDetails["permanent_error"].as<bool>() ? "true" : "false");
             }
 
             // Header autodiscovery (every 3rd message)

--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -659,6 +659,11 @@ void loop() {
                              statusDetails["permanent_error"].as<bool>() ? "true" : "false");
             }
 
+            // Header autodiscovery (every 3rd message)
+            if(userData.haAutodisc == true && adMbusMessageCounter == 3){
+              haHandoverHeader();
+            }
+
             client.publish(String(String(userData.mbusinoName) + "/debug/adMbusMessageCounter").c_str(), String(adMbusMessageCounter).c_str()); 
 
             for (uint8_t i=0; i<fields; i++) {

--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -652,11 +652,11 @@ void loop() {
               // Status details
               JsonObject statusDetails = headerObj["status_details"];
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/battery_low").c_str(),
-                             statusDetails["battery_low"].as<bool>() ? "true" : "false");
+                             statusDetails["battery_low"].as<bool>() ? "on" : "off");
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/temporary_error").c_str(),
-                             statusDetails["temporary_error"].as<bool>() ? "true" : "false");
+                             statusDetails["temporary_error"].as<bool>() ? "on" : "off");
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/permanent_error").c_str(),
-                             statusDetails["permanent_error"].as<bool>() ? "true" : "false");
+                             statusDetails["permanent_error"].as<bool>() ? "on" : "off");
             }
 
             // Header autodiscovery (every 3rd message)

--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -636,27 +636,27 @@ void loop() {
             // Publish M-Bus header via MQTT
             if (!headerObj.isNull()) {
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/address").c_str(),
-                             String(headerObj["a_field"].as<int>()).c_str());
+                             String("{\"value\":" + String(headerObj["a_field"].as<int>()) + "}").c_str());
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/id").c_str(),
-                             headerObj["id"].as<const char*>());
+                             String("{\"value\":\"" + String(headerObj["id"].as<const char*>()) + "\"}").c_str());
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/manufacturer").c_str(),
-                             headerObj["manufacturer"].as<const char*>());
+                             String("{\"value\":\"" + String(headerObj["manufacturer"].as<const char*>()) + "\"}").c_str());
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/medium").c_str(),
-                             headerObj["medium"].as<const char*>());
+                             String("{\"value\":\"" + String(headerObj["medium"].as<const char*>()) + "\"}").c_str());
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/version").c_str(),
-                             String(headerObj["version"].as<int>()).c_str());
+                             String("{\"value\":" + String(headerObj["version"].as<int>()) + "}").c_str());
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/status").c_str(),
-                             String(headerObj["status"].as<int>(), HEX).c_str());
+                             String("{\"value\":\"" + String(headerObj["status"].as<int>(), HEX) + "\"}").c_str());
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/access_counter").c_str(),
-                             String(headerObj["access_counter"].as<int>()).c_str());
+                             String("{\"value\":" + String(headerObj["access_counter"].as<int>()) + "}").c_str());
               // Status details
               JsonObject statusDetails = headerObj["status_details"];
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/battery_low").c_str(),
-                             statusDetails["battery_low"].as<bool>() ? "true" : "false");
+                             statusDetails["battery_low"].as<bool>() ? "{\"value\":100}" : "{\"value\":0}");
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/temporary_error").c_str(),
-                             statusDetails["temporary_error"].as<bool>() ? "true" : "false");
+                             statusDetails["temporary_error"].as<bool>() ? "{\"value\":\"on\"}" : "{\"value\":\"off\"}");
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/permanent_error").c_str(),
-                             statusDetails["permanent_error"].as<bool>() ? "true" : "false");
+                             statusDetails["permanent_error"].as<bool>() ? "{\"value\":\"on\"}" : "{\"value\":\"off\"}");
             }
 
             // Header autodiscovery (every 3rd message)

--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -40,7 +40,7 @@ HardwareSerial MbusSerial(1);
 MBusCom mbus(&MbusSerial,37,39);
 #endif
 
-#define MBUSINO_VERSION "1.0.2"
+#define MBUSINO_VERSION "1.0.3"
 
 #define MBUS_ADDRESS 254
 

--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -579,26 +579,57 @@ void loop() {
             }
 
             adMbusMessageCounter++;
-            int packet_size = mbus_data[1] + 6;  
+            int packet_size = mbus_data[1] + 6;
+
+            // Decode M-Bus header and publish via MQTT
+            JsonDocument headerDoc;
+            JsonObject headerObj = headerDoc.to<JsonObject>();
+            bool headerOk = payload.decodeHeader(mbus_data, packet_size, headerObj);
+            if (headerOk) {
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/address").c_str(),
+                             String(headerObj["a_field"].as<int>()).c_str());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/id").c_str(),
+                             headerObj["id"].as<const char*>());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/manufacturer").c_str(),
+                             headerObj["manufacturer"].as<const char*>());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/medium").c_str(),
+                             headerObj["medium"].as<const char*>());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/version").c_str(),
+                             String(headerObj["version"].as<int>()).c_str());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/status").c_str(),
+                             String(headerObj["status"].as<int>(), HEX).c_str());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/access_counter").c_str(),
+                             String(headerObj["access_counter"].as<int>()).c_str());
+              // Status details
+              JsonObject statusDetails = headerObj["status_details"];
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/battery_low").c_str(),
+                             statusDetails["battery_low"].as<bool>() ? "true" : "false");
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/temporary_error").c_str(),
+                             statusDetails["temporary_error"].as<bool>() ? "true" : "false");
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/permanent_error").c_str(),
+                             statusDetails["permanent_error"].as<bool>() ? "true" : "false");
+            }
+
+            // Decode M-Bus records
             JsonDocument jsonBuffer;
-            JsonArray root = jsonBuffer.add<JsonArray>();  
-            fields = payload.decode(&mbus_data[Startadd], packet_size - Startadd - 2, root); 
+            JsonArray root = jsonBuffer.add<JsonArray>();
+            fields = payload.decode(&mbus_data[Startadd], packet_size - Startadd - 2, root);
             serializeJson(root, jsonstring); // store the json in a global array
             // test -----------------------------------------------------------------------------------------
             uint16_t arraycounter = 0;
             uint8_t findTheTerminator = 1;
             while(findTheTerminator != 0){
               findTheTerminator = jsonstring[arraycounter];
-              arraycounter++;  
+              arraycounter++;
             }
-            client.publish(String(String(userData.mbusinoName) + "/MBus/jsonlen").c_str(), String(arraycounter).c_str());  
+            client.publish(String(String(userData.mbusinoName) + "/MBus/jsonlen").c_str(), String(arraycounter).c_str());
             // test ende -----------------------------------------------------------------------------------------
-            client.publish(String(String(userData.mbusinoName) + "/MBus/error").c_str(), String(payload.getError()).c_str());  // kann auskommentiert werden wenn es läuft
+            client.publish(String(String(userData.mbusinoName) + "/MBus/error").c_str(), String(payload.getError()).c_str());
             client.publish(String(String(userData.mbusinoName) + "/MBus/jsonstring").c_str(), jsonstring);
             uint8_t address = mbus_data[5];
-            client.publish(String(String(userData.mbusinoName) + "/MBus/address").c_str(), String(address).c_str());  
+            client.publish(String(String(userData.mbusinoName) + "/MBus/address").c_str(), String(address).c_str());
 
-            client.publish(String(String(userData.mbusinoName) + "/MBus/FCB").c_str(), String(fcb).c_str());  
+            client.publish(String(String(userData.mbusinoName) + "/MBus/FCB").c_str(), String(fcb).c_str());
 
             heapCalc();
             if(mbus_data[12]==0x14&&mbus_data[11]==0xC5){

--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -581,8 +581,10 @@ void loop() {
             adMbusMessageCounter++;
             int packet_size = mbus_data[1] + 6;
 
-            // Decode header and records into one shared JsonDocument
+            // one shared JsonDocument
             JsonDocument doc;
+
+            // Decode header into shared doc
             JsonObject headerObj = doc["header"].to<JsonObject>();
             bool headerOk = payload.decodeHeader(mbus_data, packet_size, headerObj);
 
@@ -601,8 +603,6 @@ void loop() {
             // test ende -----------------------------------------------------------------------------------------
             client.publish(String(String(userData.mbusinoName) + "/MBus/error").c_str(), String(payload.getError()).c_str());
             client.publish(String(String(userData.mbusinoName) + "/MBus/jsonstring").c_str(), jsonstring);
-            uint8_t address = mbus_data[5];
-            client.publish(String(String(userData.mbusinoName) + "/MBus/address").c_str(), String(address).c_str());
 
             client.publish(String(String(userData.mbusinoName) + "/MBus/FCB").c_str(), String(fcb).c_str());
 

--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -581,9 +581,9 @@ void loop() {
             adMbusMessageCounter++;
             int packet_size = mbus_data[1] + 6;
 
-            // Decode M-Bus header and publish via MQTT
-            JsonDocument headerDoc;
-            JsonObject headerObj = headerDoc.to<JsonObject>();
+            // Decode header and records into one shared JsonDocument
+            JsonDocument doc;
+            JsonObject headerObj = doc["header"].to<JsonObject>();
             bool headerOk = payload.decodeHeader(mbus_data, packet_size, headerObj);
             if (headerOk) {
               client.publish(String(String(userData.mbusinoName) + "/MBus/header/address").c_str(),
@@ -610,11 +610,10 @@ void loop() {
                              statusDetails["permanent_error"].as<bool>() ? "true" : "false");
             }
 
-            // Decode M-Bus records
-            JsonDocument jsonBuffer;
-            JsonArray root = jsonBuffer.add<JsonArray>();
-            fields = payload.decode(&mbus_data[Startadd], packet_size - Startadd - 2, root);
-            serializeJson(root, jsonstring); // store the json in a global array
+            // Decode M-Bus records into shared doc
+            JsonArray recordsArr = doc["records"].to<JsonArray>();
+            fields = payload.decodeRecords(&mbus_data[Startadd], packet_size - Startadd - 2, recordsArr);
+            serializeJson(doc, jsonstring); // store the json in a global array
             // test -----------------------------------------------------------------------------------------
             uint16_t arraycounter = 0;
             uint8_t findTheTerminator = 1;
@@ -652,18 +651,19 @@ void loop() {
         case 3:
           if(millis() - timerMbusDecoded > 100){  // Send decoded M-Bus secords via MQTT
             mbusLoopStatus = 0;
-            JsonDocument root;
-            deserializeJson(root, jsonstring); // load the json from a global array
+            JsonDocument doc;
+            deserializeJson(doc, jsonstring); // load the json from a global array
+            JsonArray recordsArr = doc["records"];
             jsonstring[0] = 0;
             client.publish(String(String(userData.mbusinoName) + "/debug/adMbusMessageCounter").c_str(), String(adMbusMessageCounter).c_str()); 
 
             for (uint8_t i=0; i<fields; i++) {
-              uint8_t code = root[i]["code"].as<int>();
-              const char* name = root[i]["name"];
-              const char* units = root[i]["units"];           
-              double value = root[i]["value_scaled"].as<double>(); 
-              const char* valueString = root[i]["value_string"];  
-              bool telegramFollow = root[i]["telegramFollow"].as<int>();   
+              uint8_t code = recordsArr[i]["code"].as<int>();
+              const char* name = recordsArr[i]["name"];
+              const char* units = recordsArr[i]["units"];           
+              double value = recordsArr[i]["value_scaled"].as<double>(); 
+              const char* valueString = recordsArr[i]["value_string"];  
+              bool telegramFollow = recordsArr[i]["telegramFollow"].as<int>();   
               
 
               if(userData.haAutodisc == true && adMbusMessageCounter == 3){  //every 264 message is a HA autoconfig message
@@ -685,8 +685,8 @@ void loop() {
                 //client.publish(String(String(userData.mbusinoName) + "/MBus/"+String(recordCounter+i+1)+"_"+String(name)+"_in_"+String(units)), String(value,3).c_str());
       
                 if (i == 3 && engelmann == true){  // Sensostar Bugfix --> comment it out if you use not a Sensostar
-                  float flow = root[5]["value_scaled"].as<float>();
-                  float delta = root[9]["value_scaled"].as<float>();
+                  float flow = recordsArr[5]["value_scaled"].as<float>();
+                  float delta = recordsArr[9]["value_scaled"].as<float>();
                   float calc_power = delta * flow * 1163;          
                   client.publish(String(String(userData.mbusinoName) + "/MBus/4_power_calc").c_str(), String(calc_power).c_str());                    
                 } 

--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -635,28 +635,22 @@ void loop() {
 
             // Publish M-Bus header via MQTT
             if (!headerObj.isNull()) {
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/address").c_str(),
-                             String(headerObj["a_field"].as<int>()).c_str());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/id").c_str(),
-                             headerObj["id"].as<const char*>());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/manufacturer").c_str(),
-                             headerObj["manufacturer"].as<const char*>());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/medium").c_str(),
-                             headerObj["medium"].as<const char*>());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/version").c_str(),
-                             String(headerObj["version"].as<int>()).c_str());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/status").c_str(),
-                             String(headerObj["status"].as<int>(), HEX).c_str());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/access_counter").c_str(),
-                             String(headerObj["access_counter"].as<int>()).c_str());
-              // Status details
-              JsonObject statusDetails = headerObj["status_details"];
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/battery_low").c_str(),
-                             statusDetails["battery_low"].as<bool>() ? "on" : "off");
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/temporary_error").c_str(),
-                             statusDetails["temporary_error"].as<bool>() ? "on" : "off");
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/permanent_error").c_str(),
-                             statusDetails["permanent_error"].as<bool>() ? "on" : "off");
+              for(uint8_t i = 0; i < HEADER_PUBLISH_COUNT; i++){
+                char valBuf[20] = {0};
+                const char* val = nullptr;
+                switch(headerPublishFields[i].type){
+                  case HT_STR: val = headerObj[headerPublishFields[i].jsonKey].as<const char*>(); break;
+                  case HT_INT: snprintf(valBuf, sizeof(valBuf), "%d", headerObj[headerPublishFields[i].jsonKey].as<int>()); val = valBuf; break;
+                  case HT_HEX: snprintf(valBuf, sizeof(valBuf), "%x", headerObj[headerPublishFields[i].jsonKey].as<int>()); val = valBuf; break;
+                  default: break;
+                }
+                if(val) client.publish(String(String(userData.mbusinoName) + "/MBus/header/" + headerPublishFields[i].jsonKey).c_str(), val);
+              }
+              JsonObject sd = headerObj["status_details"];
+              for(uint8_t i = 0; i < HEADER_STATUS_COUNT; i++){
+                client.publish(String(String(userData.mbusinoName) + "/MBus/header/" + headerStatusKeys[i]).c_str(),
+                               sd[headerStatusKeys[i]].as<bool>() ? "on" : "off");
+              }
             }
 
             // Header autodiscovery (every 3rd message)

--- a/src/MBusino/MBusino.ino
+++ b/src/MBusino/MBusino.ino
@@ -585,30 +585,6 @@ void loop() {
             JsonDocument doc;
             JsonObject headerObj = doc["header"].to<JsonObject>();
             bool headerOk = payload.decodeHeader(mbus_data, packet_size, headerObj);
-            if (headerOk) {
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/address").c_str(),
-                             String(headerObj["a_field"].as<int>()).c_str());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/id").c_str(),
-                             headerObj["id"].as<const char*>());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/manufacturer").c_str(),
-                             headerObj["manufacturer"].as<const char*>());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/medium").c_str(),
-                             headerObj["medium"].as<const char*>());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/version").c_str(),
-                             String(headerObj["version"].as<int>()).c_str());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/status").c_str(),
-                             String(headerObj["status"].as<int>(), HEX).c_str());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/access_counter").c_str(),
-                             String(headerObj["access_counter"].as<int>()).c_str());
-              // Status details
-              JsonObject statusDetails = headerObj["status_details"];
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/battery_low").c_str(),
-                             statusDetails["battery_low"].as<bool>() ? "true" : "false");
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/temporary_error").c_str(),
-                             statusDetails["temporary_error"].as<bool>() ? "true" : "false");
-              client.publish(String(String(userData.mbusinoName) + "/MBus/header/permanent_error").c_str(),
-                             statusDetails["permanent_error"].as<bool>() ? "true" : "false");
-            }
 
             // Decode M-Bus records into shared doc
             JsonArray recordsArr = doc["records"].to<JsonArray>();
@@ -653,8 +629,36 @@ void loop() {
             mbusLoopStatus = 0;
             JsonDocument doc;
             deserializeJson(doc, jsonstring); // load the json from a global array
+            JsonObject headerObj = doc["header"];
             JsonArray recordsArr = doc["records"];
             jsonstring[0] = 0;
+
+            // Publish M-Bus header via MQTT
+            if (!headerObj.isNull()) {
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/address").c_str(),
+                             String(headerObj["a_field"].as<int>()).c_str());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/id").c_str(),
+                             headerObj["id"].as<const char*>());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/manufacturer").c_str(),
+                             headerObj["manufacturer"].as<const char*>());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/medium").c_str(),
+                             headerObj["medium"].as<const char*>());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/version").c_str(),
+                             String(headerObj["version"].as<int>()).c_str());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/status").c_str(),
+                             String(headerObj["status"].as<int>(), HEX).c_str());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/access_counter").c_str(),
+                             String(headerObj["access_counter"].as<int>()).c_str());
+              // Status details
+              JsonObject statusDetails = headerObj["status_details"];
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/battery_low").c_str(),
+                             statusDetails["battery_low"].as<bool>() ? "true" : "false");
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/temporary_error").c_str(),
+                             statusDetails["temporary_error"].as<bool>() ? "true" : "false");
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/permanent_error").c_str(),
+                             statusDetails["permanent_error"].as<bool>() ? "true" : "false");
+            }
+
             client.publish(String(String(userData.mbusinoName) + "/debug/adMbusMessageCounter").c_str(), String(adMbusMessageCounter).c_str()); 
 
             for (uint8_t i=0; i<fields; i++) {

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -42,8 +42,8 @@ static const headerAdField headerAdFields[] = {
   {"status",          "Status",          ""},
   {"access_counter",  "Access Counter",  ""},
   {"battery_low",     "Battery Low",     ""},
-  {"temporary_error", "Temporary Error", "problem"},
-  {"permanent_error", "Permanent Error", "problem"},
+  {"temporary_error", "Temporary Error", ""},
+  {"permanent_error", "Permanent Error", ""},
 };
 
 #define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -48,7 +48,7 @@ static const headerAdField headerAdFields[] = {
 
 #define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))
 
-const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"M-Bus %s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
+const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value_json.value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
 
 void haHandoverHeader(){

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -48,7 +48,7 @@ static const headerAdField headerAdFields[] = {
 
 #define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))
 
-const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value_json.value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
+const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"M-Bus %s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
 
 void haHandoverHeader(){

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -31,37 +31,32 @@ struct headerAdField {
   const char* topicSuffix;
   const char* haName;
   const char* deviceClass;
-  const char* stateClass;
 };
 
 static const headerAdField headerAdFields[] = {
-  {"address",         "Address",         "", ""},
-  {"id",              "ID",              "", ""},
-  {"manufacturer",    "Manufacturer",    "", ""},
-  {"medium",          "Medium",          "", ""},
-  {"version",         "Version",         "", ""},
-  {"status",          "Status",          "", ""},
-  {"access_counter",  "Access Counter",  "", ""},
-  {"battery_low",     "Battery Low",     "", ""},
-  {"temporary_error", "Temporary Error", "", ""},
-  {"permanent_error", "Permanent Error", "", ""},
+  {"address",         "Address",         ""},
+  {"id",              "ID",              ""},
+  {"manufacturer",    "Manufacturer",    ""},
+  {"medium",          "Medium",          ""},
+  {"version",         "Version",         ""},
+  {"status",          "Status",          ""},
+  {"access_counter",  "Access Counter",  ""},
+  {"battery_low",     "Battery Low",     ""},
+  {"temporary_error", "Temporary Error", ""},
+  {"permanent_error", "Permanent Error", ""},
 };
 
 #define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))
 
-const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s%s"availability_mode":"all"})rawliteral";
+const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
 
 
 void haHandoverHeader(){
   for(uint8_t i = 0; i < HEADER_AD_FIELDS_COUNT; i++){
     char dcString[50] = {0};
-    char scString[50] = {0};
     if(headerAdFields[i].deviceClass[0] != 0){
       sprintf(dcString, "\"device_class\": \"%s\",", headerAdFields[i].deviceClass);
-    }
-    if(headerAdFields[i].stateClass[0] != 0){
-      sprintf(scString, "\"state_class\": \"%s\",", headerAdFields[i].stateClass);
     }
     sprintf(adVariables.bufferValue, adValueHeader,
       userData.mbusinoName, headerAdFields[i].topicSuffix,
@@ -69,7 +64,7 @@ void haHandoverHeader(){
       userData.mbusinoName, headerAdFields[i].topicSuffix,
       headerAdFields[i].haName,
       userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION,
-      dcString, scString);
+      dcString);
     sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, headerAdFields[i].topicSuffix);
     client.publish(adVariables.bufferTopic, adVariables.bufferValue, true);
     adVariables.bufferTopic[0] = 0;

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -31,32 +31,37 @@ struct headerAdField {
   const char* topicSuffix;
   const char* haName;
   const char* deviceClass;
+  const char* stateClass;
 };
 
 static const headerAdField headerAdFields[] = {
-  {"address",         "Address",         ""},
-  {"id",              "ID",              ""},
-  {"manufacturer",    "Manufacturer",    ""},
-  {"medium",          "Medium",          ""},
-  {"version",         "Version",         ""},
-  {"status",          "Status",          ""},
-  {"access_counter",  "Access Counter",  ""},
-  {"battery_low",     "Battery Low",     ""},
-  {"temporary_error", "Temporary Error", ""},
-  {"permanent_error", "Permanent Error", ""},
+  {"address",         "Address",         "", ""},
+  {"id",              "ID",              "", ""},
+  {"manufacturer",    "Manufacturer",    "", ""},
+  {"medium",          "Medium",          "", ""},
+  {"version",         "Version",         "", ""},
+  {"status",          "Status",          "", ""},
+  {"access_counter",  "Access Counter",  "", "total_increasing"},
+  {"battery_low",     "Battery Low",     "battery", ""},
+  {"temporary_error", "Temporary Error", "", ""},
+  {"permanent_error", "Permanent Error", "", ""},
 };
 
 #define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))
 
-const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
+const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s%s"availability_mode":"all"})rawliteral";
 const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
 
 
 void haHandoverHeader(){
   for(uint8_t i = 0; i < HEADER_AD_FIELDS_COUNT; i++){
     char dcString[50] = {0};
+    char scString[50] = {0};
     if(headerAdFields[i].deviceClass[0] != 0){
       sprintf(dcString, "\"device_class\": \"%s\",", headerAdFields[i].deviceClass);
+    }
+    if(headerAdFields[i].stateClass[0] != 0){
+      sprintf(scString, "\"state_class\": \"%s\",", headerAdFields[i].stateClass);
     }
     sprintf(adVariables.bufferValue, adValueHeader,
       userData.mbusinoName, headerAdFields[i].topicSuffix,
@@ -64,7 +69,7 @@ void haHandoverHeader(){
       userData.mbusinoName, headerAdFields[i].topicSuffix,
       headerAdFields[i].haName,
       userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION,
-      dcString);
+      dcString, scString);
     sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, headerAdFields[i].topicSuffix);
     client.publish(adVariables.bufferTopic, adVariables.bufferValue, true);
     adVariables.bufferTopic[0] = 0;

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -41,7 +41,7 @@ static const headerAdField headerAdFields[] = {
   {"version",         "Version",         ""},
   {"status",          "Status",          ""},
   {"access_counter",  "Access Counter",  ""},
-  {"battery_low",     "Battery Low",     "battery"},
+  {"battery_low",     "Battery Low",     ""},
   {"temporary_error", "Temporary Error", "problem"},
   {"permanent_error", "Permanent Error", "problem"},
 };

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -48,10 +48,10 @@ static const headerAdField headerAdFields[] = {
 
 #define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))
 
-const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"M-Bus %s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
+const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
 
-const char adValueHeaderBinary[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"binary_sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name": "%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
+const char adValueHeaderBinary[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s_bin","default_entity_id":"binary_sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name": "%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicHeaderBinary[] PROGMEM = R"rawliteral(homeassistant/binary_sensor/%s/header_%s/config)rawliteral";
 
 void haHandoverHeader(){

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -24,6 +24,51 @@ const char adTopicSensor[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/Sensor
 const char adValueBME[] PROGMEM = R"rawliteral({"unique_id":"%s__BME_%s","default_entity_id":"sensor.%s_BME_%s","state_topic":"%s/bme/%s","name":"%s","value_template":"{{value_json if value_json is defined else 0}}","unit_of_meas":"%s","state_class":"measurement","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},"device_class":"%s","availability_mode":"all"})rawliteral";
 const char adTopicBME[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/%s/config)rawliteral";
 
+// --- Header autodiscovery ---
+struct headerAdField {
+  const char* topicSuffix;
+  const char* haName;
+  const char* deviceClass;
+};
+
+static const headerAdField headerAdFields[] = {
+  {"address",         "Address",         ""},
+  {"id",              "ID",              ""},
+  {"manufacturer",    "Manufacturer",    ""},
+  {"medium",          "Medium",          ""},
+  {"version",         "Version",         ""},
+  {"status",          "Status",          ""},
+  {"access_counter",  "Access Counter",  ""},
+  {"battery_low",     "Battery Low",     "battery"},
+  {"temporary_error", "Temporary Error", "problem"},
+  {"permanent_error", "Permanent Error", "problem"},
+};
+
+#define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))
+
+const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"M-Bus %s","value_template":"{{value_json if value_json is defined else 0}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
+const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
+
+void haHandoverHeader(){
+  for(uint8_t i = 0; i < HEADER_AD_FIELDS_COUNT; i++){
+    char dcString[50] = {0};
+    if(headerAdFields[i].deviceClass[0] != 0){
+      sprintf(dcString, "\"device_class\": \"%s\",", headerAdFields[i].deviceClass);
+    }
+    sprintf(adVariables.bufferValue, adValueHeader,
+      userData.mbusinoName, headerAdFields[i].topicSuffix,
+      userData.mbusinoName, headerAdFields[i].topicSuffix,
+      userData.mbusinoName, headerAdFields[i].topicSuffix,
+      headerAdFields[i].haName,
+      userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION,
+      dcString);
+    sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, headerAdFields[i].topicSuffix);
+    client.publish(adVariables.bufferTopic, adVariables.bufferValue, true);
+    adVariables.bufferTopic[0] = 0;
+    adVariables.bufferValue[0] = 0;
+  }
+}
+
 void haHandoverMbus(uint8_t haCounter, bool engelmann){ // haCounter is the "i+1" at the for() in main
 
   if(adVariables.deviceClass[0] != 0){

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -28,49 +28,64 @@ const char adTopicBME[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/%s/config
 
 // --- Header autodiscovery ---
 struct headerAdField {
-  const char* topicSuffix;
-  const char* haName;
-  const char* deviceClass;
+  const char* jsonKey;
 };
 
 static const headerAdField headerAdFields[] = {
-  {"address",         "Address",         ""},
-  {"id",              "ID",              ""},
-  {"manufacturer",    "Manufacturer",    ""},
-  {"medium",          "Medium",          ""},
-  {"version",         "Version",         ""},
-  {"status",          "Status",          ""},
-  {"access_counter",  "Access Counter",  ""},
-  {"battery_low",     "Battery Low",     ""},
-  {"temporary_error", "Temporary Error", ""},
-  {"permanent_error", "Permanent Error", ""},
+  {"address"},
+  {"id"},
+  {"manufacturer"},
+  {"medium"},
+  {"version"},
+  {"status"},
+  {"access_counter"},
+  {"battery_low"},
+  {"temporary_error"},
+  {"permanent_error"},
 };
 
 #define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))
 
-const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
+const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},"availability_mode":"all"})rawliteral";
 const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
-
 
 void haHandoverHeader(){
   for(uint8_t i = 0; i < HEADER_AD_FIELDS_COUNT; i++){
-    char dcString[50] = {0};
-    if(headerAdFields[i].deviceClass[0] != 0){
-      sprintf(dcString, "\"device_class\": \"%s\",", headerAdFields[i].deviceClass);
-    }
     sprintf(adVariables.bufferValue, adValueHeader,
-      userData.mbusinoName, headerAdFields[i].topicSuffix,
-      userData.mbusinoName, headerAdFields[i].topicSuffix,
-      userData.mbusinoName, headerAdFields[i].topicSuffix,
-      headerAdFields[i].haName,
-      userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION,
-      dcString);
-    sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, headerAdFields[i].topicSuffix);
+      userData.mbusinoName, headerAdFields[i].jsonKey,
+      userData.mbusinoName, headerAdFields[i].jsonKey,
+      userData.mbusinoName, headerAdFields[i].jsonKey,
+      headerAdFields[i].jsonKey,
+      userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION);
+    sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, headerAdFields[i].jsonKey);
     client.publish(adVariables.bufferTopic, adVariables.bufferValue, true);
     adVariables.bufferTopic[0] = 0;
     adVariables.bufferValue[0] = 0;
   }
 }
+
+// --- Header MQTT publish ---
+enum HeaderFieldType { HT_STR, HT_INT, HT_HEX, HT_BOOL_NESTED };
+
+struct headerPublishField {
+  const char* jsonKey;
+  HeaderFieldType type;
+};
+
+static const headerPublishField headerPublishFields[] = {
+  {"address",        HT_INT},
+  {"id",             HT_STR},
+  {"manufacturer",   HT_STR},
+  {"medium",         HT_STR},
+  {"version",        HT_INT},
+  {"status",         HT_HEX},
+  {"access_counter", HT_INT},
+};
+
+#define HEADER_PUBLISH_COUNT (sizeof(headerPublishFields) / sizeof(headerPublishFields[0]))
+
+static const char* headerStatusKeys[] = {"battery_low", "temporary_error", "permanent_error"};
+#define HEADER_STATUS_COUNT (sizeof(headerStatusKeys) / sizeof(headerStatusKeys[0]))
 
 void haHandoverMbus(uint8_t haCounter, bool engelmann){ // haCounter is the "i+1" at the for() in main
 

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -51,8 +51,6 @@ static const headerAdField headerAdFields[] = {
 const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
 
-const char adValueHeaderBinary[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s_bin","default_entity_id":"binary_sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name": "%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
-const char adTopicHeaderBinary[] PROGMEM = R"rawliteral(homeassistant/binary_sensor/%s/header_%s/config)rawliteral";
 
 void haHandoverHeader(){
   for(uint8_t i = 0; i < HEADER_AD_FIELDS_COUNT; i++){
@@ -60,28 +58,14 @@ void haHandoverHeader(){
     if(headerAdFields[i].deviceClass[0] != 0){
       sprintf(dcString, "\"device_class\": \"%s\",", headerAdFields[i].deviceClass);
     }
-    if(headerAdFields[i].deviceClass[0] != 0){
-      sprintf(adVariables.bufferValue, adValueHeaderBinary,
+    sprintf(adVariables.bufferValue, adValueHeader,
       userData.mbusinoName, headerAdFields[i].topicSuffix,
       userData.mbusinoName, headerAdFields[i].topicSuffix,
       userData.mbusinoName, headerAdFields[i].topicSuffix,
       headerAdFields[i].haName,
       userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION,
       dcString);
-    }else{
-      sprintf(adVariables.bufferValue, adValueHeader,
-      userData.mbusinoName, headerAdFields[i].topicSuffix,
-      userData.mbusinoName, headerAdFields[i].topicSuffix,
-      userData.mbusinoName, headerAdFields[i].topicSuffix,
-      headerAdFields[i].haName,
-      userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION,
-      dcString);
-    }
-    if(headerAdFields[i].deviceClass[0] != 0){
-      sprintf(adVariables.bufferTopic, adTopicHeaderBinary, userData.mbusinoName, headerAdFields[i].topicSuffix);
-    }else{
-      sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, headerAdFields[i].topicSuffix);
-    }
+    sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, headerAdFields[i].topicSuffix);
     client.publish(adVariables.bufferTopic, adVariables.bufferValue, true);
     adVariables.bufferTopic[0] = 0;
     adVariables.bufferValue[0] = 0;

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -51,20 +51,37 @@ static const headerAdField headerAdFields[] = {
 const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"M-Bus %s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
 
+const char adValueHeaderBinary[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"binary_sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name": "%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
+const char adTopicHeaderBinary[] PROGMEM = R"rawliteral(homeassistant/binary_sensor/%s/header_%s/config)rawliteral";
+
 void haHandoverHeader(){
   for(uint8_t i = 0; i < HEADER_AD_FIELDS_COUNT; i++){
     char dcString[50] = {0};
     if(headerAdFields[i].deviceClass[0] != 0){
       sprintf(dcString, "\"device_class\": \"%s\",", headerAdFields[i].deviceClass);
     }
-    sprintf(adVariables.bufferValue, adValueHeader,
+    if(headerAdFields[i].deviceClass[0] != 0){
+      sprintf(adVariables.bufferValue, adValueHeaderBinary,
       userData.mbusinoName, headerAdFields[i].topicSuffix,
       userData.mbusinoName, headerAdFields[i].topicSuffix,
       userData.mbusinoName, headerAdFields[i].topicSuffix,
       headerAdFields[i].haName,
       userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION,
       dcString);
-    sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, headerAdFields[i].topicSuffix);
+    }else{
+      sprintf(adVariables.bufferValue, adValueHeader,
+      userData.mbusinoName, headerAdFields[i].topicSuffix,
+      userData.mbusinoName, headerAdFields[i].topicSuffix,
+      userData.mbusinoName, headerAdFields[i].topicSuffix,
+      headerAdFields[i].haName,
+      userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION,
+      dcString);
+    }
+    if(headerAdFields[i].deviceClass[0] != 0){
+      sprintf(adVariables.bufferTopic, adTopicHeaderBinary, userData.mbusinoName, headerAdFields[i].topicSuffix);
+    }else{
+      sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, headerAdFields[i].topicSuffix);
+    }
     client.publish(adVariables.bufferTopic, adVariables.bufferValue, true);
     adVariables.bufferTopic[0] = 0;
     adVariables.bufferValue[0] = 0;

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -6,6 +6,8 @@ struct autodiscover {
   char stateClass[30] = {0};
   char deviceClass[30] = {0};
   char deviceClassString[50] = {0};
+  char stateClassString[50] = {0};
+  char unitString[50] = {0};
 } adVariables; // home assistand auto discover
 
 const char bmeValue[4][12] = {"temperature","pressure","altitude","humidity"};
@@ -15,7 +17,7 @@ const char bmeUnits[4][5] = {"°C","mbar","m","%"};
 //const char vs[4] = "_vs"; //placeholder for insert "_vs" for valuestring is used instead of value
 //const char[4] noVs = {0}; //empty, no Valuestring
 
-const char adValueMbus[] PROGMEM = R"rawliteral({"unique_id":"%s_%u_%s","default_entity_id":"sensor.%s_%u_%s","state_topic":"%s/MBus/%u_%s","name":"%u_%s","value_template":"{{value_json if value_json is defined else 0}}","unit_of_meas":"%s","state_class":"%s","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
+const char adValueMbus[] PROGMEM = R"rawliteral({"unique_id":"%s_%u_%s","default_entity_id":"sensor.%s_%u_%s","state_topic":"%s/MBus/%u_%s","name":"%u_%s","value_template":"{{value_json if value_json is defined else 0}}",%s%s"device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicMbus[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/%u_%s/config)rawliteral";
 
 const char adValueSensor[] PROGMEM = R"rawliteral({"unique_id":"%s_Sensor%u","default_entity_id":"sensor.%s_Sensor%u","state_topic":"%s/OneWire/S%u","name":"Sensor%u","value_template":"{{value_json if value_json is defined else 0}}","unit_of_meas":"°C","state_class":"measurement","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},"device_class":"temperature","availability_mode":"all"})rawliteral";
@@ -46,7 +48,7 @@ static const headerAdField headerAdFields[] = {
 
 #define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))
 
-const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"M-Bus %s","value_template":"{{value_json if value_json is defined else 0}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
+const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"M-Bus %s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
 
 void haHandoverHeader(){
@@ -74,12 +76,18 @@ void haHandoverMbus(uint8_t haCounter, bool engelmann){ // haCounter is the "i+1
   if(adVariables.deviceClass[0] != 0){
     strcpy(adVariables.deviceClassString,String("\"device_class\": \"" + String(adVariables.deviceClass) + "\",").c_str());
   }
-  sprintf(adVariables.bufferValue,adValueMbus,userData.mbusinoName,haCounter,adVariables.haName,userData.mbusinoName,haCounter,adVariables.haName,userData.mbusinoName,haCounter,adVariables.haName,haCounter,adVariables.haName,adVariables.haUnits,adVariables.stateClass,userData.mbusinoName,userData.mbusinoName,MBUSINO_VERSION,adVariables.deviceClassString);
+  if(adVariables.stateClass[0] != 0){
+    strcpy(adVariables.stateClassString,String("\"state_class\": \"" + String(adVariables.stateClass) + "\"," ).c_str());
+  }
+  if(adVariables.haUnits[0] != 0){
+    strcpy(adVariables.unitString,String("\"unit_of_meas\": \"" + String(adVariables.haUnits) + "\"," ).c_str());
+  }
+  sprintf(adVariables.bufferValue,adValueMbus,userData.mbusinoName,haCounter,adVariables.haName,userData.mbusinoName,haCounter,adVariables.haName,userData.mbusinoName,haCounter,adVariables.haName,haCounter,adVariables.haName,adVariables.unitString,adVariables.stateClassString,userData.mbusinoName,userData.mbusinoName,MBUSINO_VERSION,adVariables.deviceClassString);
   sprintf(adVariables.bufferTopic,adTopicMbus,userData.mbusinoName,haCounter,adVariables.haName);
   client.publish(adVariables.bufferTopic, adVariables.bufferValue, true); 
 
   if (haCounter == 4 && engelmann == true){  // Sensostar Bugfix --> comment it out if you use not a Sensostar   
-    sprintf(adVariables.bufferValue,adValueMbus,userData.mbusinoName,haCounter,"power_calc",userData.mbusinoName,haCounter,"power_calc",userData.mbusinoName,haCounter,"power_calc",haCounter,"power_calc",adVariables.haUnits,adVariables.stateClass,userData.mbusinoName,userData.mbusinoName,MBUSINO_VERSION,adVariables.deviceClassString);
+    sprintf(adVariables.bufferValue,adValueMbus,userData.mbusinoName,haCounter,"power_calc",userData.mbusinoName,haCounter,"power_calc",userData.mbusinoName,haCounter,"power_calc",haCounter,"power_calc",adVariables.unitString,adVariables.stateClassString,userData.mbusinoName,userData.mbusinoName,MBUSINO_VERSION,adVariables.deviceClassString);
     sprintf(adVariables.bufferTopic,adTopicMbus,userData.mbusinoName,haCounter,"power_calc");
     client.publish(adVariables.bufferTopic, adVariables.bufferValue, true);                   
   } 
@@ -89,7 +97,9 @@ void haHandoverMbus(uint8_t haCounter, bool engelmann){ // haCounter is the "i+1
   adVariables.deviceClass[0] = 0;
   adVariables.deviceClassString[0] = 0;
   adVariables.stateClass[0] = 0;
+  adVariables.stateClassString[0] = 0;
   adVariables.haUnits[0] = 0;
+  adVariables.unitString[0] = 0;
 }
 
 void haHandoverOw(uint8_t haCounter){

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -51,7 +51,7 @@ static const headerAdField headerAdFields[] = {
 const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
 
-const char adValueHeaderBinary[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s_bin","default_entity_id":"binary_sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value == \"on\"}}","device":{"ids": ["%s"],"name": "%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
+const char adValueHeaderBinary[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s_bin","default_entity_id":"binary_sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name": "%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicHeaderBinary[] PROGMEM = R"rawliteral(homeassistant/binary_sensor/%s/header_%s/config)rawliteral";
 
 void haHandoverHeader(){

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -41,8 +41,8 @@ static const headerAdField headerAdFields[] = {
   {"medium",          "Medium",          "", ""},
   {"version",         "Version",         "", ""},
   {"status",          "Status",          "", ""},
-  {"access_counter",  "Access Counter",  "", "total_increasing"},
-  {"battery_low",     "Battery Low",     "battery", ""},
+  {"access_counter",  "Access Counter",  "", ""},
+  {"battery_low",     "Battery Low",     "", ""},
   {"temporary_error", "Temporary Error", "", ""},
   {"permanent_error", "Permanent Error", "", ""},
 };

--- a/src/MBusino/autodiscover.h
+++ b/src/MBusino/autodiscover.h
@@ -51,7 +51,7 @@ static const headerAdField headerAdFields[] = {
 const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
 
-const char adValueHeaderBinary[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s_bin","default_entity_id":"binary_sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name": "%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
+const char adValueHeaderBinary[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s_bin","default_entity_id":"binary_sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value == \"on\"}}","device":{"ids": ["%s"],"name": "%s","manufacturer": "MBusino","mdl":"V%s"},%s"availability_mode":"all"})rawliteral";
 const char adTopicHeaderBinary[] PROGMEM = R"rawliteral(homeassistant/binary_sensor/%s/header_%s/config)rawliteral";
 
 void haHandoverHeader(){

--- a/src/MBusino5S/MBusino5S.ino
+++ b/src/MBusino5S/MBusino5S.ino
@@ -790,27 +790,22 @@ void loop() {
 
             // Publish M-Bus header via MQTT
             if (!headerObj.isNull()) {
-              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/address").c_str(),
-                             String(headerObj["a_field"].as<int>()).c_str());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/id").c_str(),
-                             headerObj["id"].as<const char*>());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/manufacturer").c_str(),
-                             headerObj["manufacturer"].as<const char*>());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/medium").c_str(),
-                             headerObj["medium"].as<const char*>());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/version").c_str(),
-                             String(headerObj["version"].as<int>()).c_str());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/status").c_str(),
-                             String(headerObj["status"].as<int>(), HEX).c_str());
-              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/access_counter").c_str(),
-                             String(headerObj["access_counter"].as<int>()).c_str());
-              JsonObject statusDetails = headerObj["status_details"];
-              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/battery_low").c_str(),
-                             statusDetails["battery_low"].as<bool>() ? "on" : "off");
-              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/temporary_error").c_str(),
-                             statusDetails["temporary_error"].as<bool>() ? "on" : "off");
-              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/permanent_error").c_str(),
-                             statusDetails["permanent_error"].as<bool>() ? "on" : "off");
+              for(uint8_t i = 0; i < HEADER_PUBLISH_COUNT; i++){
+                char valBuf[20] = {0};
+                const char* val = nullptr;
+                switch(headerPublishFields[i].type){
+                  case HT_STR: val = headerObj[headerPublishFields[i].jsonKey].as<const char*>(); break;
+                  case HT_INT: snprintf(valBuf, sizeof(valBuf), "%d", headerObj[headerPublishFields[i].jsonKey].as<int>()); val = valBuf; break;
+                  case HT_HEX: snprintf(valBuf, sizeof(valBuf), "%x", headerObj[headerPublishFields[i].jsonKey].as<int>()); val = valBuf; break;
+                  default: break;
+                }
+                if(val) client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress" + String(address) + "/header/" + headerPublishFields[i].jsonKey).c_str(), val);
+              }
+              JsonObject sd = headerObj["status_details"];
+              for(uint8_t i = 0; i < HEADER_STATUS_COUNT; i++){
+                client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress" + String(address) + "/header/" + headerStatusKeys[i]).c_str(),
+                               sd[headerStatusKeys[i]].as<bool>() ? "on" : "off");
+              }
             }
 
             // Header autodiscovery

--- a/src/MBusino5S/MBusino5S.ino
+++ b/src/MBusino5S/MBusino5S.ino
@@ -42,7 +42,7 @@ HardwareSerial MbusSerial(1);
 MBusCom mbus(&MbusSerial,37,39);
 #endif
 
-#define MBUSINO_VERSION "1.0.2"
+#define MBUSINO_VERSION "1.0.3"
 
 // EEPROM flag constants
 #define EEPROM_CALIBRATED_FLAG 500

--- a/src/MBusino5S/MBusino5S.ino
+++ b/src/MBusino5S/MBusino5S.ino
@@ -743,12 +743,14 @@ void loop() {
               }
 
               int packet_size = mbus_data[1] + 6; 
-              JsonDocument jsonBuffer;
-              JsonArray root = jsonBuffer.add<JsonArray>();  
-              fields = payload.decode(&mbus_data[Startadd], packet_size - Startadd - 2, root); 
+              JsonDocument doc;
+              JsonObject headerObj = doc["header"].to<JsonObject>();
+              bool headerOk = payload.decodeHeader(mbus_data, packet_size, headerObj);
+              JsonArray recordsArr = doc["records"].to<JsonArray>();  
+              fields = payload.decodeRecords(&mbus_data[Startadd], packet_size - Startadd - 2, recordsArr); 
               address = mbus_data[5]; 
               
-              serializeJson(root, jsonstring);
+              serializeJson(doc, jsonstring);
               client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/error").c_str(), String(payload.getError()).c_str());  // kann auskommentiert werden wenn es läuft
               client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/jsonstring").c_str(), jsonstring);  
               client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/fcb").c_str(), String(fcb[currentAddressCounter]).c_str());      
@@ -780,17 +782,49 @@ void loop() {
           if(millis() - timerMbusDecoded > 100){  
             mbusLoopStatus = 0;
             shc = true;
-            JsonDocument root;
-            deserializeJson(root, jsonstring); // load the json from a global array
+            JsonDocument doc;
+            deserializeJson(doc, jsonstring);
+            JsonObject headerObj = doc["header"];
+            JsonArray recordsArr = doc["records"];
             jsonstring[0] = 0;
 
+            // Publish M-Bus header via MQTT
+            if (!headerObj.isNull()) {
+              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/address").c_str(),
+                             String(headerObj["a_field"].as<int>()).c_str());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/id").c_str(),
+                             headerObj["id"].as<const char*>());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/manufacturer").c_str(),
+                             headerObj["manufacturer"].as<const char*>());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/medium").c_str(),
+                             headerObj["medium"].as<const char*>());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/version").c_str(),
+                             String(headerObj["version"].as<int>()).c_str());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/status").c_str(),
+                             String(headerObj["status"].as<int>(), HEX).c_str());
+              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/access_counter").c_str(),
+                             String(headerObj["access_counter"].as<int>()).c_str());
+              JsonObject statusDetails = headerObj["status_details"];
+              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/battery_low").c_str(),
+                             statusDetails["battery_low"].as<bool>() ? "on" : "off");
+              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/temporary_error").c_str(),
+                             statusDetails["temporary_error"].as<bool>() ? "on" : "off");
+              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/header/permanent_error").c_str(),
+                             statusDetails["permanent_error"].as<bool>() ? "on" : "off");
+            }
+
+            // Header autodiscovery
+            if(userData.haAutodisc == true && adMbusMessageCounter == 3){
+              haHandoverHeader(address);
+            }
+
             for (uint8_t i=0; i<fields; i++) {
-              uint8_t code = root[i]["code"].as<int>();
-              const char* name = root[i]["name"];
-              const char* units = root[i]["units"];           
-              double value = root[i]["value_scaled"].as<double>();
-              const char* valueString = root[i]["value_string"];   
-              bool telegramFollow = root[i]["telegramFollow"].as<int>();    
+              uint8_t code = recordsArr[i]["code"].as<int>();
+              const char* name = recordsArr[i]["name"];
+              const char* units = recordsArr[i]["units"];           
+              double value = recordsArr[i]["value_scaled"].as<double>();
+              const char* valueString = recordsArr[i]["value_string"];   
+              bool telegramFollow = recordsArr[i]["telegramFollow"].as<int>();    
 
               if(userData.haAutodisc == true && adMbusMessageCounter == 3){  //every 254 message is a HA autoconfig message
                 strcpy(adVariables.haName,name);
@@ -812,8 +846,8 @@ void loop() {
                 //client.publish(String(String(userData.mbusinoName) +"/MBus/SlaveAddress"+String(address)+ "/MBus/"+String(i+1)+"_"+String(name)+"_in_"+String(units)), String(value,3).c_str());
 
                 if (i == 3 && engelmann == true){  // Sensostar Bugfix --> comment it out if you use not a Sensostar
-                  float flow = root[5]["value_scaled"].as<float>();
-                  float delta = root[9]["value_scaled"].as<float>();
+                  float flow = recordsArr[5]["value_scaled"].as<float>();
+                  float delta = recordsArr[9]["value_scaled"].as<float>();
                   float calc_power = delta * flow * 1163;          
                   client.publish(String(String(userData.mbusinoName) +"/MBus/SlaveAddress"+String(address)+ "/4_power_calc").c_str(), String(calc_power).c_str());                    
                 }           

--- a/src/MBusino5S/autodiscover.h
+++ b/src/MBusino5S/autodiscover.h
@@ -65,6 +65,45 @@ void haHandoverBME(){
   }
 }
 
+// --- Header autodiscovery ---
+struct headerAdField {
+  const char* topicSuffix;
+  const char* haName;
+};
+
+static const headerAdField headerAdFields[] = {
+  {"address",         "Address"},
+  {"id",              "ID"},
+  {"manufacturer",    "Manufacturer"},
+  {"medium",          "Medium"},
+  {"version",         "Version"},
+  {"status",          "Status"},
+  {"access_counter",  "Access Counter"},
+  {"battery_low",     "Battery Low"},
+  {"temporary_error", "Temporary Error"},
+  {"permanent_error", "Permanent Error"},
+};
+
+#define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))
+
+const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%u_%s","default_entity_id":"sensor.%s_header_%u_%s","state_topic":"%s/MBus/SlaveAddress%u/header/%s","name":"Addr%u_%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},"availability_mode":"all"})rawliteral";
+const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%u_%s/config)rawliteral";
+
+void haHandoverHeader(uint8_t address){
+  for(uint8_t i = 0; i < HEADER_AD_FIELDS_COUNT; i++){
+    sprintf(adVariables.bufferValue, adValueHeader,
+      userData.mbusinoName, address, headerAdFields[i].topicSuffix,
+      userData.mbusinoName, address, headerAdFields[i].topicSuffix,
+      userData.mbusinoName, address, headerAdFields[i].topicSuffix,
+      address, headerAdFields[i].haName,
+      userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION);
+    sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, address, headerAdFields[i].topicSuffix);
+    client.publish(adVariables.bufferTopic, adVariables.bufferValue, true);
+    adVariables.bufferTopic[0] = 0;
+    adVariables.bufferValue[0] = 0;
+  }
+}
+
 
 
 /*

--- a/src/MBusino5S/autodiscover.h
+++ b/src/MBusino5S/autodiscover.h
@@ -67,21 +67,20 @@ void haHandoverBME(){
 
 // --- Header autodiscovery ---
 struct headerAdField {
-  const char* topicSuffix;
-  const char* haName;
+  const char* jsonKey;
 };
 
 static const headerAdField headerAdFields[] = {
-  {"address",         "Address"},
-  {"id",              "ID"},
-  {"manufacturer",    "Manufacturer"},
-  {"medium",          "Medium"},
-  {"version",         "Version"},
-  {"status",          "Status"},
-  {"access_counter",  "Access Counter"},
-  {"battery_low",     "Battery Low"},
-  {"temporary_error", "Temporary Error"},
-  {"permanent_error", "Permanent Error"},
+  {"address"},
+  {"id"},
+  {"manufacturer"},
+  {"medium"},
+  {"version"},
+  {"status"},
+  {"access_counter"},
+  {"battery_low"},
+  {"temporary_error"},
+  {"permanent_error"},
 };
 
 #define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))
@@ -92,17 +91,40 @@ const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header
 void haHandoverHeader(uint8_t address){
   for(uint8_t i = 0; i < HEADER_AD_FIELDS_COUNT; i++){
     sprintf(adVariables.bufferValue, adValueHeader,
-      userData.mbusinoName, address, headerAdFields[i].topicSuffix,
-      userData.mbusinoName, address, headerAdFields[i].topicSuffix,
-      userData.mbusinoName, address, headerAdFields[i].topicSuffix,
-      address, headerAdFields[i].haName,
+      userData.mbusinoName, address, headerAdFields[i].jsonKey,
+      userData.mbusinoName, address, headerAdFields[i].jsonKey,
+      userData.mbusinoName, address, headerAdFields[i].jsonKey,
+      address, headerAdFields[i].jsonKey,
       userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION);
-    sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, address, headerAdFields[i].topicSuffix);
+    sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, address, headerAdFields[i].jsonKey);
     client.publish(adVariables.bufferTopic, adVariables.bufferValue, true);
     adVariables.bufferTopic[0] = 0;
     adVariables.bufferValue[0] = 0;
   }
 }
+
+// --- Header MQTT publish ---
+enum HeaderFieldType { HT_STR, HT_INT, HT_HEX, HT_BOOL_NESTED };
+
+struct headerPublishField {
+  const char* jsonKey;
+  HeaderFieldType type;
+};
+
+static const headerPublishField headerPublishFields[] = {
+  {"address",        HT_INT},
+  {"id",             HT_STR},
+  {"manufacturer",   HT_STR},
+  {"medium",         HT_STR},
+  {"version",        HT_INT},
+  {"status",         HT_HEX},
+  {"access_counter", HT_INT},
+};
+
+#define HEADER_PUBLISH_COUNT (sizeof(headerPublishFields) / sizeof(headerPublishFields[0]))
+
+static const char* headerStatusKeys[] = {"battery_low", "temporary_error", "permanent_error"};
+#define HEADER_STATUS_COUNT (sizeof(headerStatusKeys) / sizeof(headerStatusKeys[0]))
 
 
 

--- a/src/MBusinoNano/MBusinoNano.ino
+++ b/src/MBusinoNano/MBusinoNano.ino
@@ -522,10 +522,12 @@ void loop() {
 
           adMbusMessageCounter++;
           int packet_size = mbus_data[1] + 6;  
-          JsonDocument jsonBuffer;
-          JsonArray root = jsonBuffer.add<JsonArray>();  
-          fields = payload.decode(&mbus_data[Startadd], packet_size - Startadd - 2, root); 
-          serializeJson(root, jsonstring); // store the json in a global array
+          JsonDocument doc;
+          JsonObject headerObj = doc["header"].to<JsonObject>();
+          bool headerOk = payload.decodeHeader(mbus_data, packet_size, headerObj);
+          JsonArray recordsArr = doc["records"].to<JsonArray>();  
+          fields = payload.decodeRecords(&mbus_data[Startadd], packet_size - Startadd - 2, recordsArr); 
+          serializeJson(doc, jsonstring); // store the json in a global array
           // test -----------------------------------------------------------------------------------------
           uint16_t arraycounter = 0;
           uint8_t findTheTerminator = 1;
@@ -563,18 +565,45 @@ void loop() {
       case 3:
         if(millis() - timerMbusDecoded > 100){  // Send decoded M-Bus secords via MQTT
           mbusLoopStatus = 0;
-          JsonDocument root;
-          deserializeJson(root, jsonstring); // load the json from a global array
+          JsonDocument doc;
+          deserializeJson(doc, jsonstring);
+          JsonObject headerObj = doc["header"];
+          JsonArray recordsArr = doc["records"];
           jsonstring[0] = 0;
           client.publish(String(String(userData.mbusinoName) + "/debug/adMbusMessageCounter").c_str(), String(adMbusMessageCounter).c_str()); 
 
+          // Publish M-Bus header via MQTT
+          if (!headerObj.isNull()) {
+            for(uint8_t i = 0; i < HEADER_PUBLISH_COUNT; i++){
+              char valBuf[20] = {0};
+              const char* val = nullptr;
+              switch(headerPublishFields[i].type){
+                case HT_STR: val = headerObj[headerPublishFields[i].jsonKey].as<const char*>(); break;
+                case HT_INT: snprintf(valBuf, sizeof(valBuf), "%d", headerObj[headerPublishFields[i].jsonKey].as<int>()); val = valBuf; break;
+                case HT_HEX: snprintf(valBuf, sizeof(valBuf), "%x", headerObj[headerPublishFields[i].jsonKey].as<int>()); val = valBuf; break;
+                default: break;
+              }
+              if(val) client.publish(String(String(userData.mbusinoName) + "/MBus/header/" + headerPublishFields[i].jsonKey).c_str(), val);
+            }
+            JsonObject sd = headerObj["status_details"];
+            for(uint8_t i = 0; i < HEADER_STATUS_COUNT; i++){
+              client.publish(String(String(userData.mbusinoName) + "/MBus/header/" + headerStatusKeys[i]).c_str(),
+                             sd[headerStatusKeys[i]].as<bool>() ? "on" : "off");
+            }
+          }
+
+          // Header autodiscovery
+          if(userData.haAutodisc == true && adMbusMessageCounter == 3){
+            haHandoverHeader();
+          }
+
           for (uint8_t i=0; i<fields; i++) {
-            uint8_t code = root[i]["code"].as<int>();
-            const char* name = root[i]["name"];
-            const char* units = root[i]["units"];           
-            double value = root[i]["value_scaled"].as<double>(); 
-            const char* valueString = root[i]["value_string"];  
-            bool telegramFollow = root[i]["telegramFollow"].as<int>();   
+            uint8_t code = recordsArr[i]["code"].as<int>();
+            const char* name = recordsArr[i]["name"];
+            const char* units = recordsArr[i]["units"];           
+            double value = recordsArr[i]["value_scaled"].as<double>(); 
+            const char* valueString = recordsArr[i]["value_string"];  
+            bool telegramFollow = recordsArr[i]["telegramFollow"].as<int>();   
             
 
             if(userData.haAutodisc == true && adMbusMessageCounter == 3){  //every 264 message is a HA autoconfig message
@@ -596,8 +625,8 @@ void loop() {
               //client.publish(String(String(userData.mbusinoName) + "/MBus/"+String(recordCounter+i+1)+"_"+String(name)+"_in_"+String(units)), String(value,3).c_str());
     
               if (i == 3 && engelmann == true){  // Sensostar Bugfix --> comment it out if you use not a Sensostar
-                float flow = root[5]["value_scaled"].as<float>();
-                float delta = root[9]["value_scaled"].as<float>();
+                float flow = recordsArr[5]["value_scaled"].as<float>();
+                float delta = recordsArr[9]["value_scaled"].as<float>();
                 float calc_power = delta * flow * 1163;          
                 client.publish(String(String(userData.mbusinoName) + "/MBus/4_power_calc").c_str(), String(calc_power).c_str());                    
               } 

--- a/src/MBusinoNano/MBusinoNano.ino
+++ b/src/MBusinoNano/MBusinoNano.ino
@@ -33,7 +33,7 @@ You should have received a copy of the GNU General Public License along with thi
 #include <EEPROM.h>
 #include <MBusCom.h>
 
-#define MBUSINO_VERSION "1.0.2"
+#define MBUSINO_VERSION "1.0.3"
 
 // EEPROM flag constants
 #define EEPROM_CREDENTIALS_OLD 500

--- a/src/MBusinoNano/autodiscover.h
+++ b/src/MBusinoNano/autodiscover.h
@@ -44,6 +44,67 @@ void haHandoverMbus(uint8_t haCounter, bool engelmann){ // haCounter is the "i+1
   adVariables.haUnits[0] = 0;
 }
 
+// --- Header autodiscovery ---
+struct headerAdField {
+  const char* jsonKey;
+};
+
+static const headerAdField headerAdFields[] = {
+  {"address"},
+  {"id"},
+  {"manufacturer"},
+  {"medium"},
+  {"version"},
+  {"status"},
+  {"access_counter"},
+  {"battery_low"},
+  {"temporary_error"},
+  {"permanent_error"},
+};
+
+#define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))
+
+const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%s","default_entity_id":"sensor.%s_header_%s","state_topic":"%s/MBus/header/%s","name":"%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},"availability_mode":"all"})rawliteral";
+const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%s/config)rawliteral";
+
+void haHandoverHeader(){
+  for(uint8_t i = 0; i < HEADER_AD_FIELDS_COUNT; i++){
+    sprintf(adVariables.bufferValue, adValueHeader,
+      userData.mbusinoName, headerAdFields[i].jsonKey,
+      userData.mbusinoName, headerAdFields[i].jsonKey,
+      userData.mbusinoName, headerAdFields[i].jsonKey,
+      headerAdFields[i].jsonKey,
+      userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION);
+    sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, headerAdFields[i].jsonKey);
+    client.publish(adVariables.bufferTopic, adVariables.bufferValue, true);
+    adVariables.bufferTopic[0] = 0;
+    adVariables.bufferValue[0] = 0;
+  }
+}
+
+// --- Header MQTT publish ---
+enum HeaderFieldType { HT_STR, HT_INT, HT_HEX, HT_BOOL_NESTED };
+
+struct headerPublishField {
+  const char* jsonKey;
+  HeaderFieldType type;
+};
+
+static const headerPublishField headerPublishFields[] = {
+  {"address",        HT_INT},
+  {"id",             HT_STR},
+  {"manufacturer",   HT_STR},
+  {"medium",         HT_STR},
+  {"version",        HT_INT},
+  {"status",         HT_HEX},
+  {"access_counter", HT_INT},
+};
+
+#define HEADER_PUBLISH_COUNT (sizeof(headerPublishFields) / sizeof(headerPublishFields[0]))
+
+static const char* headerStatusKeys[] = {"battery_low", "temporary_error", "permanent_error"};
+#define HEADER_STATUS_COUNT (sizeof(headerStatusKeys) / sizeof(headerStatusKeys[0]))
+
 
 
 

--- a/src/MBusinoNano5S/MBusinoNano5S.ino
+++ b/src/MBusinoNano5S/MBusinoNano5S.ino
@@ -33,7 +33,7 @@ You should have received a copy of the GNU General Public License along with thi
 #include <EEPROM.h>
 #include <MBusCom.h>
 
-#define MBUSINO_VERSION "1.0.2"
+#define MBUSINO_VERSION "1.0.3"
 
 // EEPROM flag constants
 #define EEPROM_CREDENTIALS_OLD 500

--- a/src/MBusinoNano5S/MBusinoNano5S.ino
+++ b/src/MBusinoNano5S/MBusinoNano5S.ino
@@ -675,12 +675,14 @@ void loop() {
             }
 
             int packet_size = mbus_data[1] + 6; 
-            JsonDocument jsonBuffer;
-            JsonArray root = jsonBuffer.add<JsonArray>();  
-            fields = payload.decode(&mbus_data[Startadd], packet_size - Startadd - 2, root); 
+            JsonDocument doc;
+            JsonObject headerObj = doc["header"].to<JsonObject>();
+            bool headerOk = payload.decodeHeader(mbus_data, packet_size, headerObj);
+            JsonArray recordsArr = doc["records"].to<JsonArray>();  
+            fields = payload.decodeRecords(&mbus_data[Startadd], packet_size - Startadd - 2, recordsArr); 
             address = mbus_data[5]; 
             
-            serializeJson(root, jsonstring);
+            serializeJson(doc, jsonstring);
             client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/error").c_str(), String(payload.getError()).c_str());  // kann auskommentiert werden wenn es läuft
             client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/jsonstring").c_str(), jsonstring);  
             client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress"+String(address)+ "/fcb").c_str(), String(fcb[currentAddressCounter]).c_str());      
@@ -712,17 +714,44 @@ void loop() {
         if(millis() - timerMbusDecoded > 100){  
           mbusLoopStatus = 0;
           shc = true;
-          JsonDocument root;
-          deserializeJson(root, jsonstring); // load the json from a global array
+          JsonDocument doc;
+          deserializeJson(doc, jsonstring);
+          JsonObject headerObj = doc["header"];
+          JsonArray recordsArr = doc["records"];
           jsonstring[0] = 0;
 
+          // Publish M-Bus header via MQTT
+          if (!headerObj.isNull()) {
+            for(uint8_t i = 0; i < HEADER_PUBLISH_COUNT; i++){
+              char valBuf[20] = {0};
+              const char* val = nullptr;
+              switch(headerPublishFields[i].type){
+                case HT_STR: val = headerObj[headerPublishFields[i].jsonKey].as<const char*>(); break;
+                case HT_INT: snprintf(valBuf, sizeof(valBuf), "%d", headerObj[headerPublishFields[i].jsonKey].as<int>()); val = valBuf; break;
+                case HT_HEX: snprintf(valBuf, sizeof(valBuf), "%x", headerObj[headerPublishFields[i].jsonKey].as<int>()); val = valBuf; break;
+                default: break;
+              }
+              if(val) client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress" + String(address) + "/header/" + headerPublishFields[i].jsonKey).c_str(), val);
+            }
+            JsonObject sd = headerObj["status_details"];
+            for(uint8_t i = 0; i < HEADER_STATUS_COUNT; i++){
+              client.publish(String(String(userData.mbusinoName) + "/MBus/SlaveAddress" + String(address) + "/header/" + headerStatusKeys[i]).c_str(),
+                             sd[headerStatusKeys[i]].as<bool>() ? "on" : "off");
+            }
+          }
+
+          // Header autodiscovery
+          if(userData.haAutodisc == true && adMbusMessageCounter == 3){
+            haHandoverHeader(address);
+          }
+
           for (uint8_t i=0; i<fields; i++) {
-            uint8_t code = root[i]["code"].as<int>();
-            const char* name = root[i]["name"];
-            const char* units = root[i]["units"];           
-            double value = root[i]["value_scaled"].as<double>();
-            const char* valueString = root[i]["value_string"];   
-            bool telegramFollow = root[i]["telegramFollow"].as<int>();    
+            uint8_t code = recordsArr[i]["code"].as<int>();
+            const char* name = recordsArr[i]["name"];
+            const char* units = recordsArr[i]["units"];           
+            double value = recordsArr[i]["value_scaled"].as<double>();
+            const char* valueString = recordsArr[i]["value_string"];   
+            bool telegramFollow = recordsArr[i]["telegramFollow"].as<int>();    
 
             if(userData.haAutodisc == true && adMbusMessageCounter == 3){  //every 254 message is a HA autoconfig message
               strcpy(adVariables.haName,name);
@@ -744,8 +773,8 @@ void loop() {
               //client.publish(String(String(userData.mbusinoName) +"/MBus/SlaveAddress"+String(address)+ "/MBus/"+String(i+1)+"_"+String(name)+"_in_"+String(units)), String(value,3).c_str());
 
               if (i == 3 && engelmann == true){  // Sensostar Bugfix --> comment it out if you use not a Sensostar
-                float flow = root[5]["value_scaled"].as<float>();
-                float delta = root[9]["value_scaled"].as<float>();
+                float flow = recordsArr[5]["value_scaled"].as<float>();
+                float delta = recordsArr[9]["value_scaled"].as<float>();
                 float calc_power = delta * flow * 1163;          
                 client.publish(String(String(userData.mbusinoName) +"/MBus/SlaveAddress"+String(address)+ "/4_power_calc").c_str(), String(calc_power).c_str());                    
               }           

--- a/src/MBusinoNano5S/autodiscover.h
+++ b/src/MBusinoNano5S/autodiscover.h
@@ -43,3 +43,64 @@ void haHandoverMbus(uint8_t haCounter, bool engelmann, uint8_t address){ // haCo
   adVariables.stateClass[0] = 0;
   adVariables.haUnits[0] = 0;
 }
+
+// --- Header autodiscovery ---
+struct headerAdField {
+  const char* jsonKey;
+};
+
+static const headerAdField headerAdFields[] = {
+  {"address"},
+  {"id"},
+  {"manufacturer"},
+  {"medium"},
+  {"version"},
+  {"status"},
+  {"access_counter"},
+  {"battery_low"},
+  {"temporary_error"},
+  {"permanent_error"},
+};
+
+#define HEADER_AD_FIELDS_COUNT (sizeof(headerAdFields) / sizeof(headerAdFields[0]))
+
+const char adValueHeader[] PROGMEM = R"rawliteral({"unique_id":"%s_header_%u_%s","default_entity_id":"sensor.%s_header_%u_%s","state_topic":"%s/MBus/SlaveAddress%u/header/%s","name":"Addr%u_%s","value_template":"{{value}}","device":{"ids": ["%s"],"name":"%s","manufacturer": "MBusino","mdl":"V%s"},"availability_mode":"all"})rawliteral";
+const char adTopicHeader[] PROGMEM = R"rawliteral(homeassistant/sensor/%s/header_%u_%s/config)rawliteral";
+
+void haHandoverHeader(uint8_t address){
+  for(uint8_t i = 0; i < HEADER_AD_FIELDS_COUNT; i++){
+    sprintf(adVariables.bufferValue, adValueHeader,
+      userData.mbusinoName, address, headerAdFields[i].jsonKey,
+      userData.mbusinoName, address, headerAdFields[i].jsonKey,
+      userData.mbusinoName, address, headerAdFields[i].jsonKey,
+      address, headerAdFields[i].jsonKey,
+      userData.mbusinoName, userData.mbusinoName, MBUSINO_VERSION);
+    sprintf(adVariables.bufferTopic, adTopicHeader, userData.mbusinoName, address, headerAdFields[i].jsonKey);
+    client.publish(adVariables.bufferTopic, adVariables.bufferValue, true);
+    adVariables.bufferTopic[0] = 0;
+    adVariables.bufferValue[0] = 0;
+  }
+}
+
+// --- Header MQTT publish ---
+enum HeaderFieldType { HT_STR, HT_INT, HT_HEX, HT_BOOL_NESTED };
+
+struct headerPublishField {
+  const char* jsonKey;
+  HeaderFieldType type;
+};
+
+static const headerPublishField headerPublishFields[] = {
+  {"address",        HT_INT},
+  {"id",             HT_STR},
+  {"manufacturer",   HT_STR},
+  {"medium",         HT_STR},
+  {"version",        HT_INT},
+  {"status",         HT_HEX},
+  {"access_counter", HT_INT},
+};
+
+#define HEADER_PUBLISH_COUNT (sizeof(headerPublishFields) / sizeof(headerPublishFields[0]))
+
+static const char* headerStatusKeys[] = {"battery_low", "temporary_error", "permanent_error"};
+#define HEADER_STATUS_COUNT (sizeof(headerStatusKeys) / sizeof(headerStatusKeys[0]))


### PR DESCRIPTION
Decodes the M-Bus Fixed Data Header and publishes all fields via MQTT with Home Assistant autodiscovery support.

**Changes:**
-  in shared JsonDocument with header + records
- Header fields published via loop-based  struct (type-aware: STR/INT/HEX)
- Status details (battery_low, temporary_error, permanent_error) via  loop
- HA autodiscovery via  struct — jsonKey as topic + entity name
- All 4 variants: MBusino, MBusino5S, MBusinoNano, MBusinoNano5S

**MQTT Topics:**  (single) or  (5S)

**Depends on:** MBusinoLib PR #6 (a_field → address rename)